### PR TITLE
Improved performance of first enumeration

### DIFF
--- a/ramanujan/enumerators/EfficientGCFEnumerator.py
+++ b/ramanujan/enumerators/EfficientGCFEnumerator.py
@@ -4,8 +4,7 @@ from typing import List, Iterator, Callable
 from time import time
 
 from ramanujan.utils.mobius import EfficientGCF
-from ramanujan.constants import g_N_initial_search_terms, g_N_verify_terms,
-                                g_N_verify_compare_length
+from ramanujan.constants import g_N_initial_search_terms, g_N_verify_terms, g_N_verify_compare_length
 from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
 
 

--- a/ramanujan/enumerators/EfficientGCFEnumerator.py
+++ b/ramanujan/enumerators/EfficientGCFEnumerator.py
@@ -4,7 +4,8 @@ from typing import List, Iterator, Callable
 from time import time
 
 from ramanujan.utils.mobius import EfficientGCF
-from ramanujan.constants import g_N_initial_search_terms, g_N_verify_terms, g_N_verify_compare_length
+from ramanujan.constants import g_N_initial_search_terms, g_N_verify_terms,
+                                g_N_verify_compare_length
 from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
 
 
@@ -33,8 +34,9 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                              series_generator: Callable[[List[int], int], List[int]],
                              filter_from_1=False) -> [List[int], List[int]]:
         coef_list = list(coefficient_iter)
-        # create a_n and b_n series fro coefficients.
-        series_list = [series_generator(coef_list[i], g_N_initial_search_terms) for i in range(len(coef_list))]
+        # create a_n and b_n series for coefficients.
+        series_list = [series_generator(coef_list[i], g_N_initial_search_terms)
+                       for i in range(len(coef_list))]
         # filter out all options resulting in '0' in any series term.
         if filter_from_1:
             series_filter = [0 not in an[1:] for an in series_list]
@@ -47,12 +49,13 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
     def _first_enumeration(self, verbose: bool):
         """
         This is usually the bottleneck of the search.
-        We calculate general continued fractions of type K(bn,an). 'an' and 'bn' are polynomial series.
-        these polynomials take the form of n(n(..(n*c_1 + c_0) + c_2)..)+c_k.
+        We calculate general continued fractions of type K(bn,an).
+        'an' and 'bn' are polynomial series.
+        These polynomials take the form of n(n(..(n*c_1 + c_0) + c_2)..)+c_k.
         The polynomial families are supplied from self.poly_domains_generator
 
-        For each an and bn pair, a gcf is calculated using efficient_gcf_calculation defined under this scope,
-        and compared self.hash_tables for hits.
+        For each an and bn pair, a gcf is calculated using efficient_gcf_calculation
+        defined under this scope, and compared self.hash_tables for hits.
 
         :param verbose: if True print the status of calculation.
         :return: intermediate results (list of 'Match')
@@ -90,7 +93,8 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
         results = []  # list of intermediate results
 
         if size_a > size_b:  # cache {bn} in RAM, iterate over an
-            b_coef_list, bn_list = self.__create_series_list(b_coef_iter, self.create_bn_series, filter_from_1=True)
+            b_coef_list, bn_list = self.__create_series_list(b_coef_iter, self.create_bn_series,
+                                                             filter_from_1=True)
             real_bn_size = len(bn_list)
             num_iterations = (num_iterations // self.get_bn_length()) * real_bn_size
             if verbose:
@@ -103,7 +107,6 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                     print_counter += real_bn_size
                     continue
                 for bn_coef in zip(bn_list, b_coef_list):
-                    # evaluation of GCF: taken from mobius.EfficientGCF and moved here to avoid function call overhead.
                     a_ = an
                     b_ = bn_coef[0]
                     key = efficient_gcf_calculation()  # calculate hash key of gcf value
@@ -117,13 +120,14 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                             print_counter = 0
                             prediction = (time() - start)*(num_iterations / counter)
                             time_left = (time() - start)*(num_iterations / counter - 1)
-                            print(f"Passed {counter} out of {num_iterations} " +
-                                  f"({round(100. * counter / num_iterations, 2)}%). "
-                                  f"Found so far {len(results)} results. \n"
-                                  f"Time left ~{time_left:.0f}s of a total of {prediction:.0f}s")
+                            print(f'Passed {counter} out of {num_iterations} '
+                                  f'({round(100. * counter / num_iterations, 2)}%). '
+                                  f'Found so far {len(results)} results. \n'
+                                  f'Time left ~{time_left:.0f}s of a total of {prediction:.0f}s')
 
         else:  # cache {an} in RAM, iterate over bn
-            a_coef_list, an_list = self.__create_series_list(a_coef_iter, self.create_an_series, filter_from_1=True)
+            a_coef_list, an_list = self.__create_series_list(a_coef_iter, self.create_an_series,
+                                                             filter_from_1=True)
             real_an_size = len(an_list)
             num_iterations = (num_iterations // self.get_an_length()) * real_an_size
             if verbose:
@@ -149,10 +153,10 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                             print_counter = 0
                             prediction = (time() - start)*(num_iterations / counter)
                             time_left = (time() - start)*(num_iterations / counter - 1)
-                            print(f"Passed {counter} out of {num_iterations} " +
-                                  f"({round(100. * counter / num_iterations, 2)}%). "
-                                  f"Found so far {len(results)} results. \n"
-                                  f"Time left ~{time_left:.0f}s of a total of {prediction:.0f}s")
+                            print(f'Passed {counter} out of {num_iterations} '
+                                  f'({round(100. * counter / num_iterations, 2)}%). '
+                                  f'Found so far {len(results)} results. \n'
+                                  f'Time left ~{time_left:.0f}s of a total of {prediction:.0f}s')
 
         if verbose:
             print(f'created results after {time() - start:.2f}s')
@@ -177,13 +181,14 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
             try:
                 all_matches = self.hash_table.evaluate(res.lhs_key)
                 # check if all values encountered are not inf or nan
-                if not all([not (mpmath.isinf(val) or mpmath.isnan(val)) for val, _, _ in all_matches]):  # safety
+                if not all([not (mpmath.isinf(val) or mpmath.isnan(val))
+                            for val, _, _ in all_matches]):  # safety
                     print('Something wicked happened!')
                     print(f'Encountered a NAN or inf in LHS db, at {res.lhs_key}, {constant_vals}')
                     continue
             except (ZeroDivisionError, KeyError):
-                # if there was an exeption here, there is no need to halt the entire execution, but only note it to the
-                # user
+                # if there was an exeption here, there is no need to halt the entire execution,
+                # but only note it to the user
                 continue
 
             # create a_n, b_n with huge length, calculate gcf, and verify result.

--- a/ramanujan/enumerators/EfficientGCFEnumerator.py
+++ b/ramanujan/enumerators/EfficientGCFEnumerator.py
@@ -1,4 +1,3 @@
-import math
 import itertools
 import mpmath
 from typing import List, Iterator, Callable
@@ -120,7 +119,7 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                             time_left = (time() - start)*(num_iterations / counter - 1)
                             print(f"Passed {counter} out of {num_iterations} " +
                                   f"({round(100. * counter / num_iterations, 2)}%). "
-                                  f"Found so far {len(results)} results. "
+                                  f"Found so far {len(results)} results. \n"
                                   f"Time left ~{time_left:.0f}s of a total of {prediction:.0f}s")
 
         else:  # cache {an} in RAM, iterate over bn
@@ -152,7 +151,7 @@ class EfficientGCFEnumerator(AbstractGCFEnumerator):
                             time_left = (time() - start)*(num_iterations / counter - 1)
                             print(f"Passed {counter} out of {num_iterations} " +
                                   f"({round(100. * counter / num_iterations, 2)}%). "
-                                  f"Found so far {len(results)} results. "
+                                  f"Found so far {len(results)} results. \n"
                                   f"Time left ~{time_left:.0f}s of a total of {prediction:.0f}s")
 
         if verbose:

--- a/ramanujan/enumerators/ParallelGCFEnumerator.py
+++ b/ramanujan/enumerators/ParallelGCFEnumerator.py
@@ -148,19 +148,19 @@ class ParallelGCFEnumerator(EfficientGCFEnumerator):
         
         # Compute matches
         large_iter = large_iterator()
-        for ai in range(0, large_size, large_chunk):
+        for _ in range(0, large_size, large_chunk):
             large_poly["coef"], large_poly["series"] = self.__create_series_list(
                     large_iter, large_series, filter_from_1=True, iterations=large_chunk)
             if len(large_poly["series"]) == 0:  # exhausted or all 0
                 continue
                 
             small_iter = small_iterator()
-            for bi in range(0, small_size, small_chunk):
+            for _ in range(0, small_size, small_chunk):
                 start = time()
                 
                 small_poly["coef"], small_poly["series"] = self.__create_series_list(
                     small_iter, small_series, filter_from_1=True, iterations=bchunk)
-                if len(small_poly["series"]) == 0:  # bn_iter exhausted or all 0
+                if len(small_poly["series"]) == 0:  # exhausted or all 0
                     continue 
                 
                 a_ = np.array(a_poly["series"], dtype=np.float64).T

--- a/ramanujan/enumerators/ParallelGCFEnumerator.py
+++ b/ramanujan/enumerators/ParallelGCFEnumerator.py
@@ -1,0 +1,123 @@
+import itertools
+import numpy as np
+from time import time
+from typing import List, Iterator, Callable
+
+from ramanujan.constants import g_N_initial_search_terms
+from .AbstractGCFEnumerator import Match, RefinedMatch
+from .EfficientGCFEnumerator import EfficientGCFEnumerator
+
+
+class ParallelGCFEnumerator(EfficientGCFEnumerator):
+    """
+    Parallel implementation of EfficientGCFEnumerator's _first_enumeration.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @staticmethod  # Copied from EfficientGCFEnumerator, as it is a private method
+    def __create_series_list(coefficient_iter: Iterator,
+                             series_generator: Callable[[List[int], int], List[int]],
+                             filter_from_1=False) -> [List[int], List[int]]:
+        coef_list = list(coefficient_iter)
+        # create a_n and b_n series fro coefficients.
+        series_list = [series_generator(coef_list[i], g_N_initial_search_terms) for i in range(len(coef_list))]
+        # filter out all options resulting in '0' in any series term.
+        if filter_from_1:
+            series_filter = [0 not in an[1:] for an in series_list]
+        else:
+            series_filter = [0 not in an for an in series_list]
+        series_list = list(itertools.compress(series_list, series_filter))
+        coef_list = list(itertools.compress(coef_list, series_filter))
+        return coef_list, series_list
+
+
+    # Override
+    def _first_enumeration(self, verbose: bool) -> List[Match]:
+        """ See EfficientGCFEnumerator for documentation! """
+        def efficient_gcf_calculation(shape: List[int], length: int) -> np.ndarray:
+            """
+            enclosure. a_, b_, and key_factor are used from outer scope.
+            :param shape: common shape for arrays
+            :param length: common dimension of a and b
+            :return: keys for LHS hash table
+            """
+            prev_q = np.zeros(shape, dtype=np.float64)
+            q = np.ones(shape, dtype=np.float64)
+            next_q = np.empty(shape, dtype=np.float64)
+            prev_p = np.ones(shape, dtype=np.float64)
+            p = np.full(shape, a_[0, ..., np.newaxis], dtype=np.float64)  # newaxis for broadcasting
+            next_p = np.empty(shape, dtype=np.float64)
+            temp1 = np.empty(shape, dtype=np.float64)
+            temp2 = np.empty(shape, dtype=np.float64)
+            
+            for i in range(1, length):
+                temp1 = np.multiply(a_[i, ..., np.newaxis], q, out=temp1)
+                temp2 = np.multiply(b_[np.newaxis, i], prev_q, out=temp2)
+                next_q = np.add(temp1,  temp2, out=next_q)
+                
+                temp1 = np.multiply(a_[i, ..., np.newaxis], p, out=temp1)
+                temp2 = np.multiply(b_[np.newaxis, i], prev_p, out=temp2)
+                next_p = np.add(temp1, temp2, out=next_p)
+                
+                # Move references one step forward
+                prev_q, q, next_q = q, next_q, prev_q
+                prev_p, p, next_p = p, next_p, prev_p
+
+            result = np.multiply(key_factor, p, out=temp1)
+            result = np.divide(result, q, out=result, where=(q != 0))
+            return np.trunc(result, out=result)
+            
+        start = time()
+        key_factor = round(1 / self.threshold)
+        counter = print_counter = 0  # number of permutations passed
+        results = []  # list of intermediate results
+
+        a_coef_list, an_list = self.__create_series_list(
+            self.get_an_iterator(), self.create_an_series, filter_from_1=True)
+        b_coef_list, bn_list = self.__create_series_list(
+            self.get_bn_iterator(), self.create_bn_series, filter_from_1=True)
+        
+        num_iterations = len(an_list) * len(bn_list)
+        if num_iterations == 0:
+            print("Nothing to iterate over!")
+            return []
+    
+        a_ = np.array(an_list, dtype=np.float64).T
+        b_ = np.array(bn_list, dtype=np.float64).T
+        
+        if verbose:
+            print(f'Created final enumerations filters after {time() - start:.2f}s')
+            start = time()
+            
+        # calculate hash key of gcf value    
+        many_keys = efficient_gcf_calculation((*a_.shape[1:], *b_.shape[1:]), a_.shape[0])
+        print(type(many_keys[0,0]))
+            
+        if verbose:
+            print(f"Calculations in {time() - start:.2f}s")
+            start = time()
+            
+        for bind, b_coef in enumerate(b_coef_list):
+            for aind, a_coef in enumerate(a_coef_list):
+                key = int(many_keys[aind, bind])
+                if key in self.hash_table:  # find hits in hash table (bottleneck)
+                    results.append(Match(key, a_coef, b_coef))
+            
+            if verbose:
+                counter += len(an_list)
+                print_counter += len(an_list)
+                if print_counter >= 1_000_000:  # print status.
+                    print_counter = 0
+                    prediction = (time() - start)*(num_iterations / counter)
+                    time_left = (time() - start)*(num_iterations / counter - 1)
+                    print(f"Passed {counter} out of {num_iterations} " +
+                          f"({round(100. * counter / num_iterations, 2)}%). "
+                          f"Found so far {len(results)} results. "
+                          f"Time left ~{time_left:.0f}s of a total of {prediction:.0f}s")
+
+        if verbose:
+            print(f'created results after {time() - start:.2f}s')
+        return results
+            

--- a/ramanujan/enumerators/ParallelGCFEnumerator.py
+++ b/ramanujan/enumerators/ParallelGCFEnumerator.py
@@ -71,10 +71,11 @@ class ParallelGCFEnumerator(EfficientGCFEnumerator):
             q = np.ones(shape, dtype=np.float64)
             next_q = np.empty(shape, dtype=np.float64)
             prev_p = np.ones(shape, dtype=np.float64)
-            p = np.full(shape, a_[0, ..., np.newaxis], dtype=np.float64)  # newaxis for broadcasting
+            p = np.full(shape, a_[0, ..., np.newaxis], dtype=np.float64)
             next_p = np.empty(shape, dtype=np.float64)
             temp1 = np.empty(shape, dtype=np.float64)
             temp2 = np.empty(shape, dtype=np.float64)
+            # new axis for numpy broadcasting
             
             for i in range(1, length):
                 temp1 = np.multiply(a_[i, ..., np.newaxis], q, out=temp1)
@@ -128,7 +129,8 @@ class ParallelGCFEnumerator(EfficientGCFEnumerator):
         if verbose:
             chunks_total = round(np.ceil(asize / achunk) * np.ceil(bsize / bchunk))
             print(f'Created final enumerations filters after {time() - start:.2f}s')
-            print(f"Doing {num_iterations} searches in up to {chunks_total} chunks. This might take some time. ")
+            print(f"Doing {num_iterations} searches in up to {chunks_total} chunks. "
+                  f"This might take some time. ")
             start_results = time()    
         
         if aiters < biters:
@@ -153,13 +155,13 @@ class ParallelGCFEnumerator(EfficientGCFEnumerator):
                     large_iter, large_series, filter_from_1=True, iterations=large_chunk)
             if len(large_poly["series"]) == 0:  # exhausted or all 0
                 continue
-                
+            
             small_iter = small_iterator()
             for _ in range(0, small_size, small_chunk):
                 start = time()
                 
                 small_poly["coef"], small_poly["series"] = self.__create_series_list(
-                    small_iter, small_series, filter_from_1=True, iterations=bchunk)
+                    small_iter, small_series, filter_from_1=True, iterations=small_chunk)
                 if len(small_poly["series"]) == 0:  # exhausted or all 0
                     continue 
                 
@@ -188,9 +190,11 @@ class ParallelGCFEnumerator(EfficientGCFEnumerator):
                         print_counter += shape[1]
                         if print_counter >= 1_000_000:  # print status.
                             print_counter = 0
-                            prediction = ((time() - start_results - calc_time)*(num_iterations / counter)
+                            prediction = ((time() - start_results - calc_time)
+                                            *(num_iterations / counter)
                                             + calc_time * chunks_total / chunks_done)
-                            time_left = ((time() - start_results - calc_time)*(num_iterations / counter - 1)
+                            time_left = ((time() - start_results - calc_time)
+                                            *(num_iterations / counter - 1)
                                             + calc_time * (chunks_total / chunks_done - 1))
                             print(f"Passed {counter:n} out of {num_iterations:n} "
                                   f"({round(100. * counter / num_iterations, 2)}%). "


### PR DESCRIPTION
Improved the performance of Efficient GCF Enumeration and implemented a new enumeration called Parallel GCF Enumeration. The improvement to the efficient algorithm is usage of infinite precision integer math instead of mpmath floats. The parallel implementation uses numpy matrix math, but still uses only one core. Instead, it uses additional memory, which currently is limited to 0.1GB (10GB had only marginally better performance, i.e. ~1%). 

Benchmarks shows that the improved Efficient GCF Enumeration has an execution time that is about half of the original. The Parallel GCF Enumeration further reduces the execution time to less than a third of the improved version, for a total run time of less than 15% of the original algorithm. 

Details: 
e depth 20. Cartesian polynomial with an of order 1 in range [-20, 20] and bn of order 2 in range [-20, 20]. Execution time of whole script (with e pre-calculated): parallel: 146s; improved efficient: 599s; old efficient: 1256s.
pi depth 20. Cartesian polynomial with an of order 1 in range [-5, 5] and bn of order 2 in range [-30, 30]. Execution time of whole script (with pi pre-calculated): parallel: 37s; improved efficient: 125s; old efficient: 255s.

I've also added a prediction of the execution time left for the heaviest step (first enumeration) to the print messages. 

Please put it through its paces on your own searches! Any feedback is welcome. 