### PR TITLE
Private/rotem/boinc

### DIFF
--- a/ramanujan/CachedSeries.py
+++ b/ramanujan/CachedSeries.py
@@ -1,0 +1,20 @@
+from ramanujan.utils.utils import iter_series_items_from_compact_poly
+
+
+class CachedSeries(object):
+	"""
+	Handles iterating through polynomial series while caching computed items.
+	"""
+	def __init__(self, poly_coefs, series_iterator=iter_series_items_from_compact_poly):
+		self.poly_coefs = poly_coefs
+		self.series_iterator = series_iterator
+		self.cache = []
+
+	def iter_series_items(self, max_iters=1000):
+		yield from self.cache[:max_iters]
+		
+		# Calculate new items only if needed
+		itered_so_far = len(self.cache)
+		for i in self.series_iterator(self.poly_coefs, max_runs=max_iters, start_n=itered_so_far):
+			self.cache.append(i)
+			yield i

--- a/ramanujan/enumerators/AbstractGCFEnumerator.py
+++ b/ramanujan/enumerators/AbstractGCFEnumerator.py
@@ -12,7 +12,7 @@ from ramanujan.utils.convergence_rate import calculate_convergence
 from ramanujan.constants import *
 
 Match = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly')
-RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot')
+RefinedMatch = namedtuple('RefinedMatch', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot')
 FormattedResult = namedtuple('FormattedResult', 'LHS RHS GCF')
 
 

--- a/ramanujan/enumerators/AbstractGCFEnumerator.py
+++ b/ramanujan/enumerators/AbstractGCFEnumerator.py
@@ -14,7 +14,6 @@ from ramanujan.constants import *
 Match = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly')
 RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot')
 FormattedResult = namedtuple('FormattedResult', 'LHS RHS GCF')
-IterationMetadata = namedtuple('IterationMetadata', 'an_coef bn_coef iter_counter')
 
 
 def get_size_of_nested_list(list_of_elem):
@@ -37,27 +36,28 @@ class ZeroInAn(Exception):
 
 class AbstractGCFEnumerator(metaclass=ABCMeta):
     """
-        This is an abstract class for RHS searches 'engines'. 
+        This is an abstract class for RHS searches 'engines'.
 
         basically, this is a 2 step procedure:
         1) first enumeration - enumerate over all rhs combinations, find hits in lhs hash table.
             For each hit, calculate the GCF to a higher dept.
         2) refine results - take results from (1) and validate them to 100 decimal digits.
-        
-        Functions implemented in this abstract class will translate the given constants to 
-        execution limits (e.g. cast search limit to convergence threshold), handle printing 
+
+        Functions implemented in this abstract class will translate the given constants to
+        execution limits (e.g. cast search limit to convergence threshold), handle printing
         results, and making mpmath work to a sufficient precision on every location
-        
+
         Enumerators should implement the following:
             find_initial_hits
             refine_results
     """
-    def __init__(self, hash_table, poly_domains_generator, sym_constants):
+
+    def __init__(self, hash_table, poly_domains, sym_constants):
         """
         initialize search engine.
-        :param hash_table: LHSHashTable object storing the constant's permutations. Used for 
+        :param hash_table: LHSHashTable object storing the constant's permutations. Used for
             querying computed values for
-        :param poly_domains_generator: An poly_domain object that will generate polynomials to iter through, and
+        :param poly_domains: An poly_domain object that will generate polynomials to iter through, and
             supply functions for calculating items in each polynomial given
         :param sym_constants: sympy constants
         """
@@ -67,23 +67,23 @@ class AbstractGCFEnumerator(metaclass=ABCMeta):
         self.verify_dps = g_N_verify_dps  # working decimal precision for validating results.
         self.const_sym = sym_constants
         self.constants_generator = create_mpf_const_generator(sym_constants)
-        
+
         # expand poly domains object
-        # there are two methods to generate and iter over domains.  the newer one uses poly_domains_generator only,
+        # there are two methods to generate and iter over domains.  the newer one uses poly_domains only,
         # but the old one still uses the rest of the arguments.
         # generating them here to avoid breaking older enumerators
-        self.poly_domains_generator = poly_domains_generator
-        a_iterator_func, b_iterator_func = poly_domains_generator.get_calculation_method()
+        self.poly_domains = poly_domains
+        a_iterator_func, b_iterator_func = poly_domains.get_calculation_method()
         self.create_an_series = \
             lambda coefs, items: get_series_items_from_iter(a_iterator_func, coefs, items)
         self.create_bn_series = \
             lambda coefs, items: get_series_items_from_iter(b_iterator_func, coefs, items)
-        self.get_an_length = poly_domains_generator.get_an_length
-        self.get_bn_length = poly_domains_generator.get_bn_length
-        
-        self.get_an_iterator = poly_domains_generator.get_a_coef_iterator
-        self.get_bn_iterator = poly_domains_generator.get_b_coef_iterator
-        
+        self.get_an_length = poly_domains.get_an_length
+        self.get_bn_length = poly_domains.get_bn_length
+
+        self.get_an_iterator = poly_domains.get_a_coef_iterator
+        self.get_bn_iterator = poly_domains.get_b_coef_iterator
+
         # store lhs_hash_table
         self.hash_table = hash_table
 
@@ -173,10 +173,10 @@ class AbstractGCFEnumerator(metaclass=ABCMeta):
             end = time()
             if verbose:
                 print(f'that took {end - start}s')
-        
+
         return results
 
-    @abstractmethod    
+    @abstractmethod
     def _first_enumeration(self, verbose: bool):
         # override by child
         pass
@@ -199,7 +199,7 @@ class AbstractGCFEnumerator(metaclass=ABCMeta):
     @abstractmethod
     def _refine_results(self, intermediate_results: List[Match], verbose=True):
         # override by child
-        pass 
+        pass
 
     def full_execution(self):
         first_iteration = self.find_initial_hits()

--- a/ramanujan/enumerators/EfficientGCFEnumerator.py
+++ b/ramanujan/enumerators/EfficientGCFEnumerator.py
@@ -6,13 +6,7 @@ from time import time
 from ramanujan.utils.mobius import EfficientGCF
 from ramanujan.constants import g_N_initial_search_terms, g_N_verify_terms, g_N_verify_compare_length
 from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
-
-
-def trunc_division(p, q):
-    """ Integer division, rounding towards zero """
-    sign = (p < 0) + (q < 0) == 1  # if exactly one is negative
-    div = abs(p) // abs(q)
-    return -div if sign else div
+from ramanujan.utils.utils import trunc_division
 
 
 class EfficientGCFEnumerator(AbstractGCFEnumerator):

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -3,6 +3,7 @@ import mpmath
 
 from .RelativeGCFEnumerator import RelativeGCFEnumerator
 from collections import namedtuple
+from ramanujan.utils.utils import get_reduced_fraction
 
 CONVERGENCE_THRESHOLD = 0.1
 BURST_NUMBER = 200
@@ -113,14 +114,15 @@ class FREnumerator(RelativeGCFEnumerator):
             print(match)
             try:
                 pslq_res = mpmath.pslq(
-                    [1, const, -mpf_val, -const * mpf_val],
+                    [1, const, const**2, -mpf_val, -const * mpf_val, -(const**2) * mpf_val],
                     tol=10 ** (1 - precision))
             except Exception as e:
                 import ipdb
                 ipdb.set_trace()
-            print(pslq_res)
             if pslq_res:
-                pslq_results.append(RefinedMatch(*match, val, pslq_res[:2], pslq_res[2:], precision))
+                reduced_num, reduced_denom = get_reduced_fraction(pslq_res[:3], pslq_res[3:], 2)
+                print(reduced_num, reduced_denom)
+                pslq_results.append(RefinedMatch(*match, val, reduced_num, reduced_denom, precision))
             else:
                 pslq_results.append(RefinedMatch(*match, val, None, None, precision))
 

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -74,7 +74,7 @@ class FREnumerator(RelativeGCFEnumerator):
 
     def __init__(self, *args, **kwargs):
         print('checking for FR enumerator')
-        super().__init__(*args, **kwargs, hash_table=None)
+        super().__init__(None, *args, **kwargs)
 
 
     def _first_enumeration(self, print_results: bool):
@@ -120,7 +120,10 @@ class FREnumerator(RelativeGCFEnumerator):
             pslq_res = mpmath.pslq(
                 [1, consts[0], consts[0]*consts[0], -mpf_val, -consts[0]*mpf_val, -consts[0]*consts[0]*mpf_val], 
                 tol=10**(1-precision))
-            pslq_results.append(RefinedMatch(*match, val, pslq_res[:3], pslq_res[3:], precision))
+            if pslq_res:
+                pslq_results.append(RefinedMatch(*match, val, pslq_res[:3], pslq_res[3:], precision))
+            else:
+                pslq_results.append(RefinedMatch(*match, val, None, None, precision))
 
 
         return pslq_results

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -54,7 +54,8 @@ def check_for_fr(an_iterator, bn_iterator, an_deg, burst_number=BURST_NUMBER, mi
 
             # The calculated value will converge for GCFs that have FR, but it will not happen monotonicly.
             # We're calculating values once every burst_number iterations, to try and avoid fluctuations' effect
-            # If the value still isn't converging to a steady value will halt the calculation early.
+            # If the value still isn't converging to a steady value, we'll halt the calculation early.
+            # TODO - add a referrence to Guy & Nadav's paper once its on arxiv
             if num_of_calculated_vals >= 3 and \
                     abs(calculated_values[-2] - calculated_values[-1]) > \
                     abs(calculated_values[-2] - calculated_values[-3]):

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -1,0 +1,129 @@
+import math
+from time import time
+import mpmath 
+
+from .RelativeGCFEnumerator import RelativeGCFEnumerator
+from ramanujan.constants import g_N_verify_compare_length
+from collections import namedtuple
+
+CONVERGENCE_THRESHOLD = 0.1
+BURST_NUMBER = 200
+FIRST_ENUMERATION_MAX_DEPT = 5_000
+MIN_ITERS = 1
+
+Match = namedtuple('Match', 'rhs_an_poly rhs_bn_poly')
+RefinedMatch = namedtuple('Match', 'rhs_an_poly rhs_bn_poly val c_top c_bot precision')
+
+
+def check_for_fr(an_iterator, bn_iterator, metadata, an_deg, bn_deg, burst_number=BURST_NUMBER, min_iters=MIN_ITERS):
+    """
+    As the calculation for p and q goes on, the GCD for the two grows. 
+    We've noticed that conjectures tends to have a GCD that grows in a super exponential manner (we call that Factorial Reduction).
+    This function test if a GCF has factorial reduction.
+    """
+    calculated_values = []
+    num_of_calculated_vals = 0
+
+    prev_q = 0
+    q = 1
+    prev_p = 1
+    # This is a ugly hack but it works. a[0] is handled before the rest here:
+    p = an_iterator.__next__() # will place a[0] to p
+    bn_iterator.__next__() # b0 is discarded
+
+    next_gcd_calculation = burst_number if burst_number >= min_iters else min_iters
+
+    for i, (a_i, b_i) in enumerate(zip(an_iterator, bn_iterator)):
+        tmp_a = q
+        tmp_b = p
+
+        q = a_i * q + b_i * prev_q
+        p = a_i * p + b_i * prev_p
+        
+        prev_q = tmp_a
+        prev_p = tmp_b
+
+        if i == next_gcd_calculation:
+            num_of_calculated_vals += 1
+            next_gcd_calculation += burst_number
+
+            calculated_values.append(
+                mpmath.log(mpmath.mpf(math.gcd(p, q))) / mpmath.mpf(i) + \
+                    (an_deg) * (-mpmath.log(i) + 1)
+            )
+
+            # This test fails for GCF without FR. Checking it early allows us do discard a lot of GCFs
+            if num_of_calculated_vals >= 3 and \
+                abs(calculated_values[-2] - calculated_values[-1]) > abs(calculated_values[-2] - calculated_values[-3]):
+                return False, i
+
+            if num_of_calculated_vals >= 2 and \
+                abs(calculated_values[-2] - calculated_values[-1]) < CONVERGENCE_THRESHOLD:
+                return True , i
+
+    return False, i
+
+
+class FREnumerator(RelativeGCFEnumerator):
+    """
+    This enumerator checks the Factorial Reduction property of GCFs as the first step of the enumeration.
+    In the FR test we don't compute the GCF's value, or even compare it to a LHS.
+    Fractions that have FR will be computed to a higher dept using RelativeGCFEnumerator's implementation.
+    The computed values are then fed into a PSLQ that tries to find a suitable LHS.
+    """
+
+    def __init__(self, *args, **kwargs):
+        print('checking for FR enumerator')
+        super().__init__(*args, **kwargs, hash_table=None)
+
+
+    def _first_enumeration(self, print_results: bool):
+        """
+        Test all GCFs in the domain for FR.
+        """
+        num_iterations = self.poly_domains.num_iterations
+
+        start = time()
+        key_factor = 1 / self.threshold
+
+        results = []  # list of intermediate results        
+        all_items_calculated = []
+        for an_iter, bn_iter, metadata in self._iter_domains_with_cache(FIRST_ENUMERATION_MAX_DEPT):
+            has_fr, items_calculated = check_for_fr(an_iter, bn_iter, metadata,
+                self.poly_domains.get_an_degree(metadata.an_coef),
+                self.poly_domains.get_bn_degree(metadata.bn_coef))
+            if has_fr:
+                all_items_calculated.append(items_calculated)
+                if print_results:
+                    print(f"found a GCF with FR:\n\tan: {metadata.an_coef}\n\tbn:{metadata.bn_coef}")
+                # Key is useless here :)
+                results.append(Match(metadata.an_coef, metadata.bn_coef))
+
+        return results
+
+    def _improve_results_precision(self, intermediate_results, verbose=True):
+        """
+        Calculates GCFs to a higher dept using RelativeGCFEnumerator's implementation.
+        We then feed those results and the constant given to a PSLQ, that tries to find a suitable LHS.
+
+        Notice-
+        The second part of this function (PSLQ), logically belongs to the next step of the algorithm - the 
+        result refinement part. It is implemented here, because the next function is not parallelized over
+        different processes or clients, and we want the PSLQ to be parallelized as well. 
+        """
+        precise_intermediate_results = super()._improve_results_precision(intermediate_results, verbose)
+
+        pslq_results = []
+        consts = [i() for i in self.constants_generator]
+        for match, val, precision in precise_intermediate_results:
+            mpf_val = mpmath.mpf(val)
+            pslq_res = mpmath.pslq(
+                [1, consts[0], consts[0]*consts[0], -mpf_val, -consts[0]*mpf_val, -consts[0]*consts[0]*mpf_val], 
+                tol=10**(1-precision))
+            pslq_results.append(RefinedMatch(*match, val, pslq_res[:3], pslq_res[3:], precision))
+
+
+        return pslq_results
+
+    def _refine_results(self, intermediate_results, print_results=True):
+        return intermediate_results

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -10,7 +10,7 @@ FIRST_ENUMERATION_MAX_DEPT = 5_000
 MIN_ITERS = 1
 
 Match = namedtuple('Match', 'rhs_an_poly rhs_bn_poly')
-RefinedMatch = namedtuple('Match', 'rhs_an_poly rhs_bn_poly val c_top c_bot precision')
+RefinedMatch = namedtuple('RefinedMatch', 'rhs_an_poly rhs_bn_poly val c_top c_bot precision')
 
 
 def check_for_fr(an_iterator, bn_iterator, an_deg, burst_number=BURST_NUMBER, min_iters=MIN_ITERS):

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -120,6 +120,8 @@ class FREnumerator(RelativeGCFEnumerator):
                 import ipdb
                 ipdb.set_trace()
             if pslq_res:
+                # Sometimes, PSLQ can find several results for the same value (e.g. z(3)/(z(3)^2) = 1/z(3))
+                # we'll reduce fraction found to get uniform results
                 reduced_num, reduced_denom = get_reduced_fraction(pslq_res[:3], pslq_res[3:], 2)
                 print(reduced_num, reduced_denom)
                 pslq_results.append(RefinedMatch(*match, val, reduced_num, reduced_denom, precision))

--- a/ramanujan/enumerators/FREnumerator.py
+++ b/ramanujan/enumerators/FREnumerator.py
@@ -87,7 +87,7 @@ class FREnumerator(RelativeGCFEnumerator):
             if has_fr:
                 all_items_calculated.append(items_calculated)
                 if print_results:
-                    print(f"found a GCF with FR:\n\tan: {metadata.an_coef}\n\tbn:{metadata.bn_coef}")
+                    print(f"found a GCF with FR:\n\tan: {metadata.an_coef}\n\tbn: {metadata.bn_coef}")
                 # Key is useless here :)
                 results.append(Match(metadata.an_coef, metadata.bn_coef))
 

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -7,7 +7,7 @@ from ramanujan.CachedSeries import CachedSeries
 from ramanujan.constants import g_N_verify_compare_length, g_N_initial_key_length
 from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match
 
-RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot precision')
+RefinedMatch = namedtuple('RefinedMatch', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot precision')
 
 IterationMetadata = namedtuple('IterationMetadata', 'an_coef bn_coef')
 

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -112,7 +112,7 @@ def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min
 
 class RelativeGCFEnumerator(AbstractGCFEnumerator):
     """
-        This enumerator calculates the GCF to an arbitrary depth, until getting to a stable value within the precession
+        This enumerator calculates the GCF to an arbitrary depth, until getting to a stable value within the precision
         required bounds.
         Useful for GCF that converges slowly.
     """

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -97,12 +97,6 @@ def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min
                     if abs(computed_values[-2] - computed_values[-1]) > abs(computed_values[-3] - computed_values[-2]):
                         raise NotConverging("Not converging")
 
-    # The locations we calculate the GCF for and the size of the iterator is unrelated. Its likely that if we got here,
-    # that last values of the GCFs p and q were calculated but never got divided and added to computed_values
-    if i != next_gcf_calculation:
-        computed_values.append(trunc_division(precision_factor * p, q))
-        items_computed += 1
-
     # we'll take the last two calculations, and check for matching digits.
     # Once the two doesn't match, we'll know that we cannot trust the following digits.
     res = ''
@@ -112,6 +106,7 @@ def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min
         res += c1
 
     res += '0' * (len(str(computed_values[-1]))-i)
+
     return int(res), i
         
 

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -5,7 +5,9 @@ import mpmath
 
 from ramanujan.CachedSeries import CachedSeries
 from ramanujan.constants import g_N_verify_compare_length, g_N_initial_key_length
-from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
+from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match
+
+RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot precision')
 
 IterationMetadata = namedtuple('IterationMetadata', 'an_coef bn_coef')
 
@@ -110,7 +112,6 @@ def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min
 
     # we'll take the last two calculations, and check for matching digits.
     # Once the two doesn't match, we'll know that we cannot trust the following digits.
-    matching_vals = 0
     res = ''
     for i, (c1, c2) in enumerate(zip(str(computed_values[-2]), str(computed_values[-1]))):
         if c1 != c2:
@@ -186,7 +187,7 @@ class RelativeGCFEnumerator(AbstractGCFEnumerator):
         for i, (an_iter, bn_iter, metadata) in enumerate(self._iter_domains_with_cache(FIRST_STEP_MAX_ITERS)):
             try:
                 key, _ = gcf_calculation_to_precision(an_iter, bn_iter, g_N_initial_key_length, FIRST_STEP_MIN_ITERS,
-                                                   FIRST_STEP_BURST_NUMBER)
+                                                      FIRST_STEP_BURST_NUMBER)
             except (ZeroInAn, NotConverging, ZeroDivisionError):
                 continue
 
@@ -287,7 +288,7 @@ class RelativeGCFEnumerator(AbstractGCFEnumerator):
                 if val_str == rhs_str:
                     # This patch is meant to allow support for multiple matches for an
                     # LHS key, i will later be used to determine which item in the LHS dict
-                    # was matched
+                    # was matched]
                     results.append(RefinedMatch(*res, i, match[1], match[2], precision))
 
         return results

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -1,0 +1,292 @@
+from time import time
+from typing import List
+from collections import namedtuple
+import mpmath
+
+from ramanujan.CachedSeries import CachedSeries
+from ramanujan.constants import g_N_verify_terms, g_N_verify_compare_length, g_N_initial_key_length
+from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
+
+IterationMetadata = namedtuple('IterationMetadata', 'an_coef bn_coef')
+RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot precision')
+
+FIRST_STEP_MIN_ITERS = 7
+FIRST_STEP_MAX_ITERS = 100
+FIRST_STEP_BURST_NUMBER = 7
+
+SECOND_STEP_MIN_ITERS = 7
+SECOND_STEP_MAX_ITERS = 10_000
+SECOND_STEP_BURST_NUMBER = 7
+
+
+class ZeroInAn(Exception):
+    pass
+
+
+class NotConverging(Exception):
+    pass
+
+
+# TODO - pass this function to utils.
+def trunc_division(p, q):
+    """ Integer division, rounding towards zero """
+    sign = (p < 0) + (q < 0) == 1  # if exactly one is negative
+    div = abs(p) // abs(q)
+    return -div if sign else div
+
+
+def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min_iters, burst_number):
+    """
+    Calculate the GCF's value to a changing dept that depends on the GCF's convergence rate.
+
+    Most GCFs will converge by oscillation. If we calculate the GCF's value on the n and n+1 dept, we can conclude
+    (for most GCFs) that the resulting value will be between those two values. Using this principle, we'll stop the
+    GCF's calculation when those two values have the same decimal value under the required approximation.
+
+    If the value didn't converge and the iterators are not yielding any new items, we'll take the last two values calculated for  
+    the GCF and compare their digits. As long as the digits are the match - we'll assume that it is a real value. 
+
+    Since huge int division is a costly process, we'll do so only every burst_number of calculations.
+
+    Returns an integer with the matching key for the GCF, which is int(gcf_value*precision_factor) and the number of digits 
+    calculated.
+    """
+    computed_values = []
+    items_computed = 0
+
+    # Some GCFs converge by oscillation. its better to take odd burst_number to test
+    # values from both sub-series
+    burst_number = burst_number if burst_number % 2 == 1 else burst_number + 1
+    next_gcf_calculation = burst_number if burst_number >= min_iters else min_iters
+
+    precision_factor = 10 ** result_precision
+    prev_q = 0
+    q = 1
+    prev_p = 1
+    # This is a ugly hack but it works. a[0] is handled before the rest here:
+    p = an_iterator.__next__()  # will place a[0] to p
+    bn_iterator.__next__()  # b0 is discarded
+
+    if p == 0:
+        raise ZeroInAn()
+
+    for i, (a_i, b_i) in enumerate(zip(an_iterator, bn_iterator)):
+        if a_i == 0:
+            raise ZeroInAn()
+
+        # a_i is the (i+1)'th item of an, and b_i the the i'th item of bn
+        tmp_a = q
+        tmp_b = p
+
+        q = a_i * q + b_i * prev_q
+        p = a_i * p + b_i * prev_p
+
+        prev_q = tmp_a
+        prev_p = tmp_b
+
+        if i == next_gcf_calculation:
+            next_gcf_calculation += burst_number * (len(computed_values) + 1)
+            if q != 0:  # safety check
+                computed_values.append(trunc_division(precision_factor * p, q))
+                items_computed += 1
+            else:
+                raise ZeroDivisionError()
+
+            if items_computed >= 2:
+                if computed_values[-1] == computed_values[-2]:
+                    return computed_values[-1], result_precision
+
+                if items_computed >= 3:
+                    # if the GCF oscillates between two sub-series - we expect the distance between the two to 
+                    # monotonically decrease. If the GCF doesn't oscillate, we expect the distance between two following values to
+                    # monotonically decrease as well. If none of those apply, we halt the calculation here.
+                    if abs(computed_values[-2] - computed_values[-1]) > abs(computed_values[-3] - computed_values[-2]):
+                        raise NotConverging("Not converging")
+
+    # The locations we calculate the GCF for and the size of the iterator is unrelated. Its likely that if we got here,
+    # that last values of the GCFs p and q were calculated but never got divided and added to computed_values
+    if i != next_gcf_calculation:
+        computed_values.append(trunc_division(precision_factor * p, q))
+        items_computed += 1
+
+    # we'll take the last two calculations, and check for matching digits.
+    # Once the two doesn't match, we'll know that we cannot trust the following digits.
+    matching_vals = 0
+    res = ''
+    for i, (c1, c2) in enumerate(zip(str(computed_values[-2]), str(computed_values[-1]))):
+        if c1 != c2:
+            break
+        res += c1
+
+    res += '0' * (len(str(computed_values[-1]))-i)
+    return int(res), i
+        
+
+class RelativeGCFEnumerator(AbstractGCFEnumerator):
+    """
+        This enumerator calculates the GCF to an arbitrary dept, until getting to a stable value within the precession
+        required bounds.
+        Useful for GCF that converges slowly.
+    """
+
+    def __init__(self, *args, **kwargs):
+        print('using relative enumerator')
+        super().__init__(*args, **kwargs)
+
+    def _iter_domains_with_cache(self, max_iters):
+        """
+        Yields an and bn pairs in the given domain while keeping cache for one of the series (an or bn)
+        to avoid double calculations.
+
+        We allow calculations up to max_iters, and we'll avoid calculating items we don't use, so the 
+        item in an or bn is only calculated when it's first yielded and then cached.
+        """
+        size_a = self.poly_domains.an_length
+        size_b = self.poly_domains.bn_length
+
+        an_series_iter, bn_series_iter = self.poly_domains.get_calculation_method()
+
+        # The series on the outer loop is only used on one iteration of the out loop. So
+        # we'll cache only the current series for it. All of the domain for the inner series is cached
+        if size_a > size_b:  # cache bn
+            bn_cache = {}
+            an_cache = CachedSeries((0,), an_series_iter)
+            for an_coefs, bn_coefs in self.poly_domains.iter_polys(primary_looped_domain='a'):
+                if bn_coefs not in bn_cache:
+                    bn_cache[bn_coefs] = CachedSeries(bn_coefs, bn_series_iter)
+                if an_cache.poly_coefs != an_coefs:
+                    an_cache = CachedSeries(an_coefs, an_series_iter)
+
+                yield (
+                    an_cache.iter_series_items(max_iters=max_iters),
+                    bn_cache[bn_coefs].iter_series_items(max_iters=max_iters),
+                    IterationMetadata(an_coefs, bn_coefs))
+
+        else:  # cache an
+            an_cache = {}
+            bn_cache = CachedSeries((0,), bn_series_iter)
+            for an_coefs, bn_coefs in self.poly_domains.iter_polys(primary_looped_domain='b'):
+                if an_coefs not in an_cache:
+                    an_cache[an_coefs] = CachedSeries(an_coefs, an_series_iter)
+                if bn_cache.poly_coefs != bn_coefs:
+                    bn_cache = CachedSeries(bn_coefs, bn_series_iter)
+
+                yield (
+                    an_cache[an_coefs].iter_series_items(max_iters=max_iters),
+                    bn_cache.iter_series_items(max_iters=max_iters),
+                    IterationMetadata(an_coefs, bn_coefs))
+
+    def _first_enumeration(self, verbose: bool):
+        """
+        Calculate the GCD to a low precision and check for hits with the bloom filter
+        """
+        start = time()
+
+        results = []  # list of intermediate results        
+        next_status_print = 100_000
+        for i, (an_iter, bn_iter, metadata) in enumerate(self._iter_domains_with_cache(FIRST_STEP_MAX_ITERS)):
+            try:
+                key, _ = gcf_calculation_to_precision(an_iter, bn_iter, g_N_initial_key_length, FIRST_STEP_MIN_ITERS,
+                                                   FIRST_STEP_BURST_NUMBER)
+            except (ZeroInAn, NotConverging, ZeroDivisionError):
+                continue
+
+            if key in self.hash_table:  # find hits in hash table
+                results.append(Match(key, metadata.an_coef, metadata.bn_coef))
+
+            if i == next_status_print:  # print status.
+                next_status_print += 1000
+                print(
+                    f'passed {i} out of {self.poly_domains.num_iterations} ' +
+                    f'({round(100. * i / self.poly_domains.num_iterations, 2)}%). ' +
+                    f' found so far {len(results)} results')
+                print(f'currently at an = {metadata.an_coef} bn = {metadata.bn_coef}')
+
+        if verbose:
+            print(f'created results after {time() - start}s')
+            print(f'found {len(results)} results')
+        return results
+
+    def _improve_results_precision(self, intermediate_results: List[Match], verbose=True):
+        """
+        For each results, calculate the GCD to a higher dept, and return the calculated result 
+        with the original result.
+        """
+        precise_results = []
+        counter = 0
+        n_iterations = len(intermediate_results)
+        key_factor = 10 ** g_N_verify_compare_length
+        an_series_iter, bn_series_iter = self.poly_domains.get_calculation_method()
+
+        for res in intermediate_results:
+            counter += 1
+            
+            if (counter % 10_000 == 0 or counter == n_iterations) and verbose:
+                print('Calculated {} matches out of {} to a more precise value.'.format(
+                    counter, n_iterations))
+
+            an_iter = an_series_iter(res.rhs_an_poly, SECOND_STEP_MAX_ITERS, start_n=0)
+            bn_iter = bn_series_iter(res.rhs_bn_poly, SECOND_STEP_MAX_ITERS, start_n=0)
+            try:
+                long_key, precision = gcf_calculation_to_precision(an_iter, bn_iter, g_N_verify_compare_length,
+                                                        min_iters=SECOND_STEP_MIN_ITERS,
+                                                        burst_number=SECOND_STEP_BURST_NUMBER)
+            except NotConverging as e:
+                print(f"{res} does not converge. Continuing...")
+                continue
+            except (ZeroInAn, ZeroDivisionError) as e:
+                print(f" exception for {res}. Continuing...")
+                print(e)
+                continue
+
+            rhs_val = mpmath.mpf(long_key) / key_factor
+            rhs_str = mpmath.nstr(rhs_val, precision)
+
+            precise_results.append((res, rhs_str, precision))
+        return precise_results
+
+    def _refine_results(self, precise_intermediate_results, verbose=True):
+        """
+        This step is identical to the one in Efficient enumerator. The two we're quite different in the
+        rest of the implementation, so it didn't feel right to extend EfficientGCFEnumerator in this class.
+        Hence, there is some code duplication here
+
+        validate intermediate results to 100 digit precision
+        :param precise_intermediate_results:  list of results from first enumeration
+        :param verbose: if true print status.
+        :return: final results.
+        """
+        results = []
+        counter = 0
+        n_iterations = len(precise_intermediate_results)
+        constant_vals = [const() for const in self.constants_generator]
+
+        for res, rhs_str, precision in precise_intermediate_results:
+            counter += 1
+            if (counter % 10_000 == 0 or counter == n_iterations) and verbose:
+                print('Passed {} permutations out of {}. Found so far {} matches'.format(
+                    counter, n_iterations, len(results)))
+            try:
+                all_matches = self.hash_table.evaluate(res.lhs_key)
+                # check if all values encountered are not inf or nan
+                if not all([not (mpmath.isinf(val) or mpmath.isnan(val))
+                            for val, _, _ in all_matches]):  # safety
+                    print('Something wicked happened!')
+                    print(f'Encountered a NAN or inf in LHS db, at {res.lhs_key}, {constant_vals}')
+                    continue
+            except (ZeroDivisionError, KeyError):
+                # if there was an exception here, there is no need to halt the entire execution,
+                # but only note it to the user
+                continue
+
+            for i, match in enumerate(all_matches):
+                # TODO - trunc_division will flat to 0, while nstr will do the right thing
+                # this forces the value to be flatted to zero.
+                val_str = mpmath.nstr(match[0], precision + 1)[:-1]
+                if val_str == rhs_str:
+                    # This patch is meant to allow support for multiple matches for an
+                    # LHS key, i will later be used to determine which item in the LHS dict
+                    # was matched
+                    results.append(RefinedMatch(*res, i, match[1], match[2], precision))
+
+        return results

--- a/ramanujan/enumerators/RelativeGCFEnumerator.py
+++ b/ramanujan/enumerators/RelativeGCFEnumerator.py
@@ -4,11 +4,10 @@ from collections import namedtuple
 import mpmath
 
 from ramanujan.CachedSeries import CachedSeries
-from ramanujan.constants import g_N_verify_terms, g_N_verify_compare_length, g_N_initial_key_length
+from ramanujan.constants import g_N_verify_compare_length, g_N_initial_key_length
 from .AbstractGCFEnumerator import AbstractGCFEnumerator, Match, RefinedMatch
 
 IterationMetadata = namedtuple('IterationMetadata', 'an_coef bn_coef')
-RefinedMatch = namedtuple('Match', 'lhs_key rhs_an_poly rhs_bn_poly lhs_match_idx c_top c_bot precision')
 
 FIRST_STEP_MIN_ITERS = 7
 FIRST_STEP_MAX_ITERS = 100
@@ -98,8 +97,8 @@ def gcf_calculation_to_precision(an_iterator, bn_iterator, result_precision, min
 
                 if items_computed >= 3:
                     # if the GCF oscillates between two sub-series - we expect the distance between the two to 
-                    # monotonically decrease. If the GCF doesn't oscillate, we expect the distance between two following values to
-                    # monotonically decrease as well. If none of those apply, we halt the calculation here.
+                    # monotonically decrease. If the GCF doesn't oscillate, we expect the distance between two following
+                    # values to monotonically decrease as well. If none of those apply, we halt the calculation here.
                     if abs(computed_values[-2] - computed_values[-1]) > abs(computed_values[-3] - computed_values[-2]):
                         raise NotConverging("Not converging")
 
@@ -227,12 +226,14 @@ class RelativeGCFEnumerator(AbstractGCFEnumerator):
 
             an_iter = an_series_iter(res.rhs_an_poly, SECOND_STEP_MAX_ITERS, start_n=0)
             bn_iter = bn_series_iter(res.rhs_bn_poly, SECOND_STEP_MAX_ITERS, start_n=0)
+
             try:
                 long_key, precision = gcf_calculation_to_precision(an_iter, bn_iter, g_N_verify_compare_length,
-                                                        min_iters=SECOND_STEP_MIN_ITERS,
-                                                        burst_number=SECOND_STEP_BURST_NUMBER)
+                                                                   min_iters=SECOND_STEP_MIN_ITERS,
+                                                                   burst_number=SECOND_STEP_BURST_NUMBER)
             except NotConverging as e:
                 print(f"{res} does not converge. Continuing...")
+                print(e)
                 continue
             except (ZeroInAn, ZeroDivisionError) as e:
                 print(f" exception for {res}. Continuing...")

--- a/ramanujan/multiprocess_enumeration.py
+++ b/ramanujan/multiprocess_enumeration.py
@@ -14,13 +14,17 @@ class Dummy(object):
 
 
 def _single_process_execution(enumerator_class, lhs, poly_search_domain, const_vals):
-    enumerator = enumerator_class(
-        lhs,
-        poly_search_domain,
-        const_vals)
-    
-    return enumerator.find_initial_hits()
+    if lhs:
+        enumerator = enumerator_class(
+            lhs,
+            poly_search_domain,
+            const_vals)
+    else:
+        enumerator = enumerator_class(
+            poly_search_domain,
+            const_vals)
 
+    return enumerator.find_initial_hits()
 
 def multiprocess_enumeration(enumerator_class, lhs, poly_search_domain, const_vals, number_of_processes):
     """
@@ -41,7 +45,8 @@ def multiprocess_enumeration(enumerator_class, lhs, poly_search_domain, const_va
     
     # Each subprocess only uses lhs.bloom. See Dummy class doc for more details.
     lean_lhs = Dummy()
-    lean_lhs.bloom = lhs.bloom
+    # Some enumerators don't require the LHS, passing None instead
+    lean_lhs.bloom = lhs.bloom if lhs else None
 
     # Creating arguments for each process function
     split_domain = poly_search_domain.split_domains_to_processes(number_of_processes)
@@ -62,7 +67,11 @@ def multiprocess_enumeration(enumerator_class, lhs, poly_search_domain, const_va
 
     # Create another enumerator (should not take time to initiate) and preforme 
     # the second step using only it
-    enumerator = enumerator_class(lhs, poly_search_domain, const_vals)
+    if lhs:
+        enumerator = enumerator_class(lhs, poly_search_domain, const_vals)
+    else:
+        enumerator = enumerator_class(poly_search_domain, const_vals)
+
     refined_results = enumerator.refine_results(unified_results)
 
     return refined_results

--- a/ramanujan/poly_domains/AbstractPolyDomains.py
+++ b/ramanujan/poly_domains/AbstractPolyDomains.py
@@ -38,7 +38,8 @@ class AbstractPolyDomains(metaclass=ABCMeta):
 	def get_num_iterations(self):
 		pass
 
-	def get_calculation_method(self):
+	@staticmethod
+	def get_calculation_method():
 		pass
 
 	def dump_domain_ranges(self):

--- a/ramanujan/poly_domains/CartesianProductPolyDomain.py
+++ b/ramanujan/poly_domains/CartesianProductPolyDomain.py
@@ -61,7 +61,8 @@ class CartesianProductPolyDomain(AbstractPolyDomains):
 	def get_bn_length(self):
 		return CartesianProductPolyDomain.domain_size_by_var_ranges(self.b_coef_range)
 
-	def get_calculation_method(self):
+	@staticmethod
+	def get_calculation_method():
 		# both an and bn are regular compact polys
 		return iter_series_items_from_compact_poly, \
 			iter_series_items_from_compact_poly

--- a/ramanujan/poly_domains/CartesianProductPolyDomain.py
+++ b/ramanujan/poly_domains/CartesianProductPolyDomain.py
@@ -143,7 +143,6 @@ class CartesianProductPolyDomain(AbstractPolyDomains):
             sub_domains.append(next_instance)
 
         if biggest_range['size'] < number_of_instances:
-            print('rec')
             # divide the required instances over all of the sub domains
             smaller_sub_domains = []
             for i, sub_domain in zip(array_split(range(number_of_instances), len(sub_domains)), sub_domains):

--- a/ramanujan/poly_domains/CartesianProductPolyDomain.py
+++ b/ramanujan/poly_domains/CartesianProductPolyDomain.py
@@ -2,142 +2,153 @@ from .AbstractPolyDomains import AbstractPolyDomains
 from ..utils.utils import iter_series_items_from_compact_poly
 from itertools import product
 from copy import deepcopy
+from numpy import array_split
 
 
 class CartesianProductPolyDomain(AbstractPolyDomains):
-	"""
-	This poly domain will generate all combinations for a(n) and b(n) coefs without complex dependence between the two
-	"""
-	def __init__(self, a_deg, a_coef_range, b_deg, b_coef_range, an_leading_coef_positive=True, *args, **kwargs):
-		"""
-		If all of an's coefs can get both positive and negative values, then we might get two iterations for any set of
-		coefs, with opposite signs. Those two series will converge to the same value, but with a different sign, hence
-		it is a redundant run we can skip. Based on an_leading_coef_positive we will try to detect those cases and skip
-		them
-		"""
-		self.a_deg = a_deg
-		# expanding the range to a different range for each coef
-		# allows us to use the same functions for decedent classes
-		self.a_coef_range = [list(a_coef_range) for _ in range(a_deg + 1)]
-		if an_leading_coef_positive and self.a_coef_range[-1][0] <= 0:
-			self.a_coef_range[0][0] = 1
+    """
+    This poly domain will generate all combinations for a(n) and b(n) coefs without complex dependence between the two
+    """
+    def __init__(self, a_deg, a_coef_range, b_deg, b_coef_range, an_leading_coef_positive=True, *args, **kwargs):
+        """
+        If all of an's coefs can get both positive and negative values, then we might get two iterations for any set of
+        coefs, with opposite signs. Those two series will converge to the same value, but with a different sign, hence
+        it is a redundant run we can skip. Based on an_leading_coef_positive we will try to detect those cases and skip
+        them
+        """
+        self.a_deg = a_deg
+        # expanding the range to a different range for each coef
+        # allows us to use the same functions for decedent classes
+        self.a_coef_range = [list(a_coef_range) for _ in range(a_deg + 1)]
+        if an_leading_coef_positive and self.a_coef_range[-1][0] <= 0:
+            self.a_coef_range[0][0] = 1
 
-		self.b_deg = b_deg
-		self.b_coef_range = [b_coef_range for _ in range(b_deg + 1)]
+        self.b_deg = b_deg
+        self.b_coef_range = [b_coef_range for _ in range(b_deg + 1)]
 
-		self._setup_metadata()
-		super().__init__()
+        self._setup_metadata()
+        super().__init__()
 
-	def _setup_metadata(self):
-		"""
-		This function generates and stores values that should not change throughout the run.
-		It continues __init__'s job, but holds code that is used in classes that extend this class, so it was
-		moved to a separate function.
-		"""
-		self.an_length = self.get_an_length()
-		self.bn_length = self.get_bn_length()
-		self.num_iterations = self.an_length * self.bn_length
+    def _setup_metadata(self):
+        """
+        This function generates and stores values that should not change throughout the run.
+        It continues __init__'s job, but holds code that is used in classes that extend this class, so it was
+        moved to a separate function.
+        """
+        self.an_length = self.get_an_length()
+        self.bn_length = self.get_bn_length()
+        self.num_iterations = self.an_length * self.bn_length
 
-		self.an_domain_range, self.bn_domain_range = self.dump_domain_ranges()
+        self.an_domain_range, self.bn_domain_range = self.dump_domain_ranges()
 
-	@staticmethod
-	def _range_size(coef_range):
-		return coef_range[1] - coef_range[0] + 1
+    @staticmethod
+    def _range_size(coef_range):
+        return coef_range[1] - coef_range[0] + 1
 
-	@staticmethod
-	def domain_size_by_var_ranges(var_ranges):
-		size = 1
-		for var_range in var_ranges:
-			size *= CartesianProductPolyDomain._range_size(var_range)
-		return size
+    @staticmethod
+    def domain_size_by_var_ranges(var_ranges):
+        size = 1
+        for var_range in var_ranges:
+            size *= CartesianProductPolyDomain._range_size(var_range)
+        return size
 
-	@staticmethod
-	def expand_coef_range_to_full_domain(coef_ranges):
-		return [[i for i in range(coef[0], coef[1] + 1)] for coef in coef_ranges]
+    @staticmethod
+    def expand_coef_range_to_full_domain(coef_ranges):
+        return [[i for i in range(coef[0], coef[1] + 1)] for coef in coef_ranges]
 
-	def get_an_length(self):
-		return CartesianProductPolyDomain.domain_size_by_var_ranges(self.a_coef_range)
+    def get_an_length(self):
+        return CartesianProductPolyDomain.domain_size_by_var_ranges(self.a_coef_range)
 
-	def get_bn_length(self):
-		return CartesianProductPolyDomain.domain_size_by_var_ranges(self.b_coef_range)
+    def get_bn_length(self):
+        return CartesianProductPolyDomain.domain_size_by_var_ranges(self.b_coef_range)
 
-	@staticmethod
-	def get_calculation_method():
-		# both an and bn are regular compact polys
-		return iter_series_items_from_compact_poly, \
-			iter_series_items_from_compact_poly
+    @staticmethod
+    def get_calculation_method():
+        # both an and bn are regular compact polys
+        return iter_series_items_from_compact_poly, \
+            iter_series_items_from_compact_poly
 
-	def dump_domain_ranges(self):
-		an_domain = CartesianProductPolyDomain.expand_coef_range_to_full_domain(self.a_coef_range)
-		bn_domain = CartesianProductPolyDomain.expand_coef_range_to_full_domain(self.b_coef_range)
+    def dump_domain_ranges(self):
+        an_domain = CartesianProductPolyDomain.expand_coef_range_to_full_domain(self.a_coef_range)
+        bn_domain = CartesianProductPolyDomain.expand_coef_range_to_full_domain(self.b_coef_range)
 
-		return an_domain, bn_domain
+        return an_domain, bn_domain
 
-	def iter_polys(self, primary_looped_domain):
-		an_domain, bn_domain = self.dump_domain_ranges()
+    def iter_polys(self, primary_looped_domain):
+        an_domain, bn_domain = self.dump_domain_ranges()
 
-		if primary_looped_domain == 'a':
-			a_coef_iter = product(*an_domain)
-			for a_coef in a_coef_iter:
-				b_coef_iter = product(*bn_domain)
-				for b_coef in b_coef_iter:
-					yield a_coef, b_coef
-		else:
-			b_coef_iter = product(*bn_domain)
-			for b_coef in b_coef_iter:
-				a_coef_iter = product(*an_domain)
-				for a_coef in a_coef_iter:
-					yield a_coef, b_coef
+        if primary_looped_domain == 'a':
+            a_coef_iter = product(*an_domain)
+            for a_coef in a_coef_iter:
+                b_coef_iter = product(*bn_domain)
+                for b_coef in b_coef_iter:
+                    yield a_coef, b_coef
+        else:
+            b_coef_iter = product(*bn_domain)
+            for b_coef in b_coef_iter:
+                a_coef_iter = product(*an_domain)
+                for a_coef in a_coef_iter:
+                    yield a_coef, b_coef
 
-	def get_a_coef_iterator(self):
-		return product(*self.an_domain_range)
+    def get_a_coef_iterator(self):
+        return product(*self.an_domain_range)
 
-	def get_b_coef_iterator(self):
-		return product(*self.bn_domain_range)
+    def get_b_coef_iterator(self):
+        return product(*self.bn_domain_range)
 
-	def get_individual_polys_generators(self):
-		# for backwards compatibility.
-		return self.get_a_coef_iterator(), self.get_b_coef_iterator()
+    def get_individual_polys_generators(self):
+        # for backwards compatibility.
+        return self.get_a_coef_iterator(), self.get_b_coef_iterator()
 
-	@staticmethod
-	def _get_metadata_on_var_ranges(ranges, series):
-		ranges_metadata = []
-		for i, v in enumerate(ranges):
-			ranges_metadata.append({
-				'range': v,
-				'size': v[1]-v[0]+1,
-				'series': series,
-				'index': i
-				})
-		return ranges_metadata
+    @staticmethod
+    def _get_metadata_on_var_ranges(ranges, series):
+        ranges_metadata = []
+        for i, v in enumerate(ranges):
+            ranges_metadata.append({
+                'range': v,
+                'size': v[1]-v[0]+1,
+                'series': series,
+                'index': i
+                })
+        return ranges_metadata
 
-	def split_domains_to_processes(self, number_of_instances):
-		"""
-		When using multiprocessing, we'll split the search domain to several polyDomain and iter over each one
-		in a different process.
-		This function will split the domain to number_of_instances sub-domains. To do so, we'll find the coef
-		with the biggest range, and split it as evenly as possible to different instances.
-		"""
-		all_coef_ranges = self._get_metadata_on_var_ranges(self.a_coef_range, 'a')
-		all_coef_ranges += self._get_metadata_on_var_ranges(self.b_coef_range, 'b')
+    def split_domains_to_processes(self, number_of_instances):
+        """
+        When using multiprocessing, we'll split the search domain to several polyDomain and iter over each one
+        in a different process.
+        This function will split the domain to number_of_instances sub-domains. To do so, we'll find the coef
+        with the biggest range, and split it as evenly as possible to different instances.
+        """
+        all_coef_ranges = self._get_metadata_on_var_ranges(self.a_coef_range, 'a')
+        all_coef_ranges += self._get_metadata_on_var_ranges(self.b_coef_range, 'b')
 
-		biggest_range = max(all_coef_ranges, key=lambda x: x['size'])
+        biggest_range = max(all_coef_ranges, key=lambda x: x['size'])
 
-		# split the range to chunks here, modify the last chunk so it will cover the last value,
-		# avoiding off by 1 errors
-		chunk_size = biggest_range['size'] // number_of_instances
-		range_start, range_end = biggest_range['range']
-		split_range = [[range_start+i*chunk_size, range_start+(i+1)*chunk_size-1] for i in range(number_of_instances-1)]
-		split_range.append([range_start+(number_of_instances-1)*chunk_size, range_end])
+        # when splitting over a huge number of processes (probably over different clients) we'll not be able to
+        # split the domain using only one coef. If that's the case, we'll just split the biggest coef as much as 
+        # we can, and use the same logic recursively over every sub-domain.
+        number_of_sub_arrays = min(number_of_instances, biggest_range['size'])
+        
+        sub_domains = []
+        for chunk_items in array_split(range(biggest_range['range'][0], biggest_range['range'][1] + 1),
+                                       number_of_sub_arrays):
+            chunk_range = [int(chunk_items[0]), int(chunk_items[-1])]
+            next_instance = deepcopy(self)
+            if biggest_range['series'] == 'a':
+                next_instance.a_coef_range[biggest_range['index']] = chunk_range
+            else:
+                next_instance.b_coef_range[biggest_range['index']] = chunk_range
 
-		sub_domains = []
-		for i, chunk_range in zip(range(number_of_instances), split_range):
-			next_instance = deepcopy(self)
-			if biggest_range['series'] == 'a':
-				next_instance.a_coef_range[biggest_range['index']] = chunk_range
-			else:
-				next_instance.b_coef_range[biggest_range['index']] = chunk_range
+            next_instance._setup_metadata()
+            sub_domains.append(next_instance)
 
-			next_instance._setup_metadata()
-			sub_domains.append(next_instance)
-		return sub_domains
+        if biggest_range['size'] < number_of_instances:
+            print('rec')
+            # divide the required instances over all of the sub domains
+            smaller_sub_domains = []
+            for i, sub_domain in zip(array_split(range(number_of_instances), len(sub_domains)), sub_domains):
+                smaller_sub_domains += sub_domain.split_domains_to_processes(len(i))
+
+            return smaller_sub_domains
+
+        return sub_domains

--- a/ramanujan/poly_domains/ExamplePolyDomain.py
+++ b/ramanujan/poly_domains/ExamplePolyDomain.py
@@ -13,7 +13,7 @@ class ExampleDomain(CartesianProductPolyDomain):
 
     This is a descendant of CartesianProductPolyDomain since each coef is independent from the others.
     """
-    def __init__(self, a_coefs_ranges, b_coef_range, *args, ** kwargs):
+    def __init__(self, a_coefs_ranges, b_coef_range, a_deg, a_coef_range, b_deg, *args, **kwargs):
         """
         Under this function you'll need to create 2 objects:
         1. a_coef_range
@@ -23,6 +23,7 @@ class ExampleDomain(CartesianProductPolyDomain):
         :param a_coefs_ranges:  ranges for an coefs, as described above
         :param b_coef_range:  bn has only one coef, so this is the range for it - [c_3_min, c_3_max]
         """
+        super().__init__(a_deg, a_coef_range, b_deg, b_coef_range, *args, **kwargs)
         self.a_coef_range = a_coefs_ranges
         # bn's coef range is converted to the expected form.
         self.b_coef_range = [b_coef_range]

--- a/ramanujan/poly_domains/Zeta3Domain1.py
+++ b/ramanujan/poly_domains/Zeta3Domain1.py
@@ -50,7 +50,7 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 		return an_iterator, bn_iterator
 
 	@staticmethod
-	def get_poly_an_degree(an_coefs):
+	def get_an_degree(an_coefs):
 		deg = 3
 		if an_coefs[0] == 0:
 			deg -= 1
@@ -59,7 +59,7 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 		return deg
 
 	@staticmethod
-	def get_poly_bn_degree(bn_coefs):
+	def get_bn_degree(bn_coefs):
 		# bn_coefs is not used since the degree is always 0. Still accepting this variable for consistency
 		return 6
 

--- a/ramanujan/poly_domains/Zeta3Domain1.py
+++ b/ramanujan/poly_domains/Zeta3Domain1.py
@@ -19,7 +19,7 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 	NOTICE - Since every coeffiecnt is given explicitly, we do not enforce that the leading coef of an will always be
 	positive. (See CartesianProductPolyDomain documnetation regarding an_leading_coef_positive for more information)
 	"""
-	def __init__(self, a_coefs_ranges, b_coef_range, *args, **kwargs):
+	def __init__(self, a_coefs_ranges=[[0,0]], b_coef_range=[0,0], *args, **kwargs):
 		"""
 		:param a_coefs_ranges: the range allowed for each coef from x0,x1,x2,x3
 		in this format-
@@ -37,7 +37,8 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 
 		self.an_domain_range, self.bn_domain_range = self.dump_domain_ranges()
 
-	def get_calculation_method(self):
+	@staticmethod
+	def get_calculation_method():
 		def an_iterator(free_vars, max_runs, start_n=1):
 			for i in range(start_n, max_runs):
 				yield (free_vars[0]*i + free_vars[1])*(free_vars[2]*i*(i+1) + free_vars[3])

--- a/ramanujan/poly_domains/Zeta3Domain1.py
+++ b/ramanujan/poly_domains/Zeta3Domain1.py
@@ -19,7 +19,7 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 	NOTICE - Since every coeffiecnt is given explicitly, we do not enforce that the leading coef of an will always be
 	positive. (See CartesianProductPolyDomain documnetation regarding an_leading_coef_positive for more information)
 	"""
-	def __init__(self, a_coefs_ranges=[[0,0]], b_coef_range=[0,0], *args, **kwargs):
+	def __init__(self, a_coefs_ranges=((0, 0),), b_coef_range=(0, 0), *args, **kwargs):
 		"""
 		:param a_coefs_ranges: the range allowed for each coef from x0,x1,x2,x3
 		in this format-
@@ -60,7 +60,7 @@ class Zeta3Domain1(CartesianProductPolyDomain):
 
 	@staticmethod
 	def get_bn_degree(bn_coefs):
-		# bn_coefs is not used since the degree is always 0. Still accepting this variable for consistency
+		# bn_coefs is not used since the degree is always 6. Still accepting this variable for consistency
 		return 6
 
 	@staticmethod

--- a/ramanujan/poly_domains/Zeta3Domain2.py
+++ b/ramanujan/poly_domains/Zeta3Domain2.py
@@ -1,4 +1,5 @@
-from .CartesianProductPolyDomain import * 
+from .CartesianProductPolyDomain import CartesianProductPolyDomain 
+from itertools import product
 
 
 class Zeta3Domain2(CartesianProductPolyDomain):

--- a/ramanujan/poly_domains/Zeta3Domain2.py
+++ b/ramanujan/poly_domains/Zeta3Domain2.py
@@ -1,16 +1,16 @@
 from .CartesianProductPolyDomain import * 
 
 class Zeta3Domain2(CartesianProductPolyDomain):
-	'''
+	"""
 	This domain iters polynomials from this kind:
 	a(n) = x0*n^3 + x0*(n+1)^3 + x1(2n+1)
-	b(n) = x2*n^6
+	b(n) = -(x2**2)*n^6
 
 	Note that all zeta3 results shown in the paper can be written using this
 	scheme. 
 
 	It is suggested to keep x1,x2<0, but this is not enforced by this class 
-	'''
+	"""
 
 	def __init__(self, a_coefs_ranges, b_coef_range, *args, **kwargs):
 		# a_coef_range and b_coef_range are given blank values. they are initialized again afterwards
@@ -28,7 +28,7 @@ class Zeta3Domain2(CartesianProductPolyDomain):
 
 		def bn_iterator(b_coefs, max_runs, start_n=1):
 			for i in range(start_n, max_runs):
-				yield b_coefs[0]*(i**6)
+				yield -(b_coefs[0]**2)*(i**6)
 
 		return an_iterator, bn_iterator
 
@@ -46,7 +46,7 @@ class Zeta3Domain2(CartesianProductPolyDomain):
 
 	@staticmethod
 	def get_poly_bn_lead_coef(bn_coefs):
-		return bn_coefs[0]
+		return -bn_coefs[0]**2
 	
 	@staticmethod
 	def check_for_convergence(an_coefs, bn_coefs):
@@ -54,7 +54,7 @@ class Zeta3Domain2(CartesianProductPolyDomain):
 		a_leading_coef = an_coefs[0] * 2
 
 		# checking for >= as well as >, might be overkill
-		return bn_coefs[0] * 4 >= -1 * (a_leading_coef**2)
+		return -1 * (bn_coefs[0]**2) * 4 >= -1 * (a_leading_coef**2)
 
 	def iter_polys(self, primary_looped_domain):
 		an_domain, bn_domain = self.dump_domain_ranges()

--- a/ramanujan/poly_domains/Zeta3Domain2.py
+++ b/ramanujan/poly_domains/Zeta3Domain2.py
@@ -12,7 +12,7 @@ class Zeta3Domain2(CartesianProductPolyDomain):
 	It is suggested to keep x1,x2<0, but this is not enforced by this class 
 	"""
 
-	def __init__(self, a_coefs_ranges, b_coef_range, *args, **kwargs):
+	def __init__(self, a_coefs_ranges=[[0,0]], b_coef_range=[0,0], *args, **kwargs):
 		# a_coef_range and b_coef_range are given blank values. they are initialized again afterwards
 		super().__init__(a_deg=2, b_deg=1, a_coef_range=[0, 0], b_coef_range=[0, 0], *args, **kwargs)
 		self.a_coef_range = a_coefs_ranges

--- a/ramanujan/poly_domains/Zeta3Domain2.py
+++ b/ramanujan/poly_domains/Zeta3Domain2.py
@@ -1,5 +1,6 @@
 from .CartesianProductPolyDomain import * 
 
+
 class Zeta3Domain2(CartesianProductPolyDomain):
 	"""
 	This domain iters polynomials from this kind:
@@ -12,7 +13,7 @@ class Zeta3Domain2(CartesianProductPolyDomain):
 	It is suggested to keep x1,x2<0, but this is not enforced by this class 
 	"""
 
-	def __init__(self, a_coefs_ranges=[[0,0]], b_coef_range=[0,0], *args, **kwargs):
+	def __init__(self, a_coefs_ranges=((0, 0),), b_coef_range=(0, 0), *args, **kwargs):
 		# a_coef_range and b_coef_range are given blank values. they are initialized again afterwards
 		super().__init__(a_deg=2, b_deg=1, a_coef_range=[0, 0], b_coef_range=[0, 0], *args, **kwargs)
 		self.a_coef_range = a_coefs_ranges

--- a/ramanujan/poly_domains/Zeta3Domain2.py
+++ b/ramanujan/poly_domains/Zeta3Domain2.py
@@ -1,0 +1,77 @@
+from .CartesianProductPolyDomain import * 
+
+class Zeta3Domain2(CartesianProductPolyDomain):
+	'''
+	This domain iters polynomials from this kind:
+	a(n) = x0*n^3 + x0*(n+1)^3 + x1(2n+1)
+	b(n) = x2*n^6
+
+	Note that all zeta3 results shown in the paper can be written using this
+	scheme. 
+
+	It is suggested to keep x1,x2<0, but this is not enforced by this class 
+	'''
+
+	def __init__(self, a_coefs_ranges, b_coef_range, *args, **kwargs):
+		# a_coef_range and b_coef_range are given blank values. they are initialized again afterwards
+		super().__init__(a_deg=2, b_deg=1, a_coef_range=[0, 0], b_coef_range=[0, 0], *args, **kwargs)
+		self.a_coef_range = a_coefs_ranges
+		self.b_coef_range = [b_coef_range]
+
+		self._setup_metadata()
+
+	@staticmethod
+	def get_calculation_method():
+		def an_iterator(a_coefs, max_runs, start_n=1):
+			for i in range(start_n, max_runs):
+				yield a_coefs[0]*((i+1)**3 + i**3) + a_coefs[1]*(2*i+1)
+
+		def bn_iterator(b_coefs, max_runs, start_n=1):
+			for i in range(start_n, max_runs):
+				yield b_coefs[0]*(i**6)
+
+		return an_iterator, bn_iterator
+
+	@staticmethod
+	def get_an_degree(an_coefs):
+		return 3
+
+	@staticmethod
+	def get_bn_degree(bn_coefs):
+		return 6
+
+	@staticmethod
+	def get_poly_an_lead_coef(an_coefs):
+		return an_coefs[0]*2
+
+	@staticmethod
+	def get_poly_bn_lead_coef(bn_coefs):
+		return bn_coefs[0]
+	
+	@staticmethod
+	def check_for_convergence(an_coefs, bn_coefs):
+		# see Ramanujan paper for convergence condition on balanced an & bn degrees
+		a_leading_coef = an_coefs[0] * 2
+
+		# checking for >= as well as >, might be overkill
+		return bn_coefs[0] * 4 >= -1 * (a_leading_coef**2)
+
+	def iter_polys(self, primary_looped_domain):
+		an_domain, bn_domain = self.dump_domain_ranges()
+
+		# TODO
+		# try calling super's iter_polys and check convergence for yielded polys
+		if primary_looped_domain == 'a':
+			a_coef_iter = product(*an_domain)
+			for a_coef in a_coef_iter:
+				b_coef_iter = product(*bn_domain)
+				for b_coef in b_coef_iter:
+					if self.check_for_convergence(a_coef, b_coef):
+						yield a_coef, b_coef
+		else:
+			b_coef_iter = product(*bn_domain)
+			for b_coef in b_coef_iter:
+				a_coef_iter = product(*an_domain)
+				for a_coef in a_coef_iter:
+					if self.check_for_convergence(a_coef, b_coef):
+						yield a_coef, b_coef

--- a/ramanujan/utils/utils.py
+++ b/ramanujan/utils/utils.py
@@ -3,7 +3,7 @@ from typing import List
 import time
 import mpmath
 import matplotlib.pyplot as plt
-from sympy import lambdify
+from sympy import lambdify, var, Poly
 
 
 def trunc_division(p, q):
@@ -171,7 +171,33 @@ def plot_gcf_convergens(an_poly_coef, bn_poly_coef, max_iters, divide_interval=1
     plt.figure(g_current_fig)
     plt.plot([i[1] for i in computed_values], [i[0] for i in computed_values], '+')
     plt.ion()
+    plt.grid()
+    plt.xlabel("n")
+    plt.ylabel("GCF value")
     plt.title(label=label)
     plt.show()
 
     return computed_values
+
+
+def get_reduced_fraction(numerator_coefs, denominator_coefs, result_deg):
+    """
+    Reduce polynomial division by common factors. So (1+k)/(1+2k+k**2) will be reduced to 1/(1+k)
+    Items in the coefs list start from the lowest degree ([a, b, c] = a + b*x +c*x**2)
+
+    """
+    k = var('k')
+    numerator = sum([coef * k**i for i, coef in enumerate(numerator_coefs)])
+    denominator = sum([coef * k**i for i, coef in enumerate(denominator_coefs)])
+
+    reduced_num, reduced_denom = (numerator/denominator).simplify().as_numer_denom()
+    reduced_num_coefs, reduced_denom_coefs = Poly(reduced_num, k).all_coeffs(), Poly(reduced_denom, k).all_coeffs()
+    reduced_num_coefs.reverse()
+    reduced_denom_coefs.reverse()
+
+    # If the higher degrees are missing from the expression, then the list will have a smaller size then needed.
+    # Adding zeros as padding to the end.
+    reduced_num_coefs += [0] * (result_deg + 1 - len(reduced_num_coefs))
+    reduced_denom_coefs += [0] * (result_deg + 1 - len(reduced_denom_coefs))
+
+    return reduced_num_coefs, reduced_denom_coefs

--- a/ramanujan/utils/utils.py
+++ b/ramanujan/utils/utils.py
@@ -5,6 +5,14 @@ import mpmath
 import matplotlib.pyplot as plt
 from sympy import lambdify
 
+
+def trunc_division(p, q):
+    """ Integer division, rounding towards zero """
+    sign = (p < 0) + (q < 0) == 1  # if exactly one is negative
+    div = abs(p) // abs(q)
+    return -div if sign else div
+
+
 # Measures the amount of time the function takes to run in milliseconds in order to check improvements
 def measure_performance(func):
     """

--- a/scripts/boinc/execute_from_json.py
+++ b/scripts/boinc/execute_from_json.py
@@ -1,0 +1,64 @@
+import json
+import os
+import sys
+import json
+import time
+import ramanujan
+import pybloom_live
+from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+from ramanujan.constants import g_const_dict
+from ramanujan.LHSHashTable import LHSHashTable
+from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
+
+# we're gonna have to load all of the domains :(
+from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+
+enumerators = {
+    "EfficientGCFEnumerator": EfficientGCFEnumerator
+}
+domains = {
+    "Zeta3Domain1": Zeta3Domain1
+}
+
+class Dummy(object):
+    pass
+
+def get_consts_objects(consts):
+    const_objects = []
+    for i in consts:
+        if isinstance(i, tuple) or isinstance(i, list):
+            const_objects.append(g_const_dict[i[0]](i[1]))
+        else:
+            const_objects.append(g_const_dict[i])
+    return const_objects
+
+def main():
+    json_path = sys.argv[1]
+    bloom_path = sys.argv[2]
+
+    with open(json_path, 'r') as f:
+        config = json.load(f)
+
+    lean_lhs = Dummy()
+    with open(bloom_path, 'rb') as f:
+        lean_lhs.bloom = pybloom_live.BloomFilter.fromfile(f)
+
+    poly_domain = domains[config["domain_type"]]()
+    poly_domain.a_coef_range = config["an_coefs"]
+    poly_domain.b_coef_range = config["bn_coefs"]
+    poly_domain._setup_metadata()
+
+    const_vals = get_consts_objects(config["const_list"])
+
+    enumerator = enumerators[config["enumerator"]](
+        lean_lhs.bloom,
+        poly_domain,
+        const_vals)
+
+    results = enumerator.find_initial_hits()
+        print(results)
+
+    # TODO - write results to file
+
+if __name__ == '__main__':
+    main()

--- a/scripts/boinc/execute_from_json.py
+++ b/scripts/boinc/execute_from_json.py
@@ -1,27 +1,24 @@
-import json
 import os
 import sys
 import json
-import time
-import ramanujan
-import pybloom_live
 from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
+from ramanujan.poly_domains.CartesianProductPolyDomain import CartesianProductPolyDomain
+
 from ramanujan.constants import g_const_dict
-from ramanujan.LHSHashTable import LHSHashTable
-from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
+from ramanujan.enumerators.FREnumerator import FREnumerator
 
-# we're gonna have to load all of the domains :(
-from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
 
-enumerators = {
-    "EfficientGCFEnumerator": EfficientGCFEnumerator
+ENUMERATORS = {
+    "FREnumerator": FREnumerator
 }
-domains = {
-    "Zeta3Domain1": Zeta3Domain1
+DOMAINS = {
+    "Zeta3Domain1": Zeta3Domain1,
+    "Zeta3Domain2": Zeta3Domain2,
+    "CartesianProductPolyDomain": CartesianProductPolyDomain
 }
+RESULTS_FILE_PATH_FORMAT = '{id}_results.json'
 
-class Dummy(object):
-    pass
 
 def get_consts_objects(consts):
     const_objects = []
@@ -32,33 +29,29 @@ def get_consts_objects(consts):
             const_objects.append(g_const_dict[i])
     return const_objects
 
+
 def main():
     json_path = sys.argv[1]
-    bloom_path = sys.argv[2]
+    unique_id = os.path.split(json_path)[1].rsplit('.', 1)[0]
 
     with open(json_path, 'r') as f:
         config = json.load(f)
 
-    lean_lhs = Dummy()
-    with open(bloom_path, 'rb') as f:
-        lean_lhs.bloom = pybloom_live.BloomFilter.fromfile(f)
-
-    poly_domain = domains[config["domain_type"]]()
+    poly_domain = DOMAINS[config["domain_type"]]()
     poly_domain.a_coef_range = config["an_coefs"]
     poly_domain.b_coef_range = config["bn_coefs"]
     poly_domain._setup_metadata()
 
     const_vals = get_consts_objects(config["const_list"])
-
-    enumerator = enumerators[config["enumerator"]](
-        lean_lhs.bloom,
+    enumerator = ENUMERATORS[config["enumerator"]](
         poly_domain,
         const_vals)
 
     results = enumerator.find_initial_hits()
-        print(results)
 
-    # TODO - write results to file
+    with open(RESULTS_FILE_PATH_FORMAT.format(id=unique_id), 'w') as f:
+        json.dump(results, f)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/boinc/split_execution.py
+++ b/scripts/boinc/split_execution.py
@@ -1,12 +1,8 @@
 import os
 import json
 import time
-import ramanujan
 from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
-from ramanujan.constants import g_const_dict
-from ramanujan.LHSHashTable import LHSHashTable
-from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
-from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
 
 
 """
@@ -14,74 +10,61 @@ In this script, we create multiple jobs from a single execution scheme.
 For each job save a json that stores the execution parameters. 
 Those jsons will be sent to different hosts from a BOINC server
 
-The bloom filter is saved 
+Currently, we're planning on distributing FREnumerator only, so there is no support for 
+bloom filter distribution.
 """
-SPLITTED_DOMAIN_CHUNK_SIZE = 100_000
+SPLIT_DOMAIN_CHUNK_SIZE = 100
 BLOOM_LOCAL_PATH = "./{0}_bloom.bin"
-JSON_FORMAT = "./{folder}/{id}.json"
+JSON_NAME_FORMAT = "./{folder}/{filename}.json"
 
-ALLOWD_ENUMERATORS = [
-    "EfficientGCFEnumerator"
+ALLOWED_ENUMERATORS = [
+    "FREnumerator"
 ]
+POLY_DOMAINS_MAPPING = {
+    'Zeta3Domain1': Zeta3Domain1,
+    'Zeta3Domain2': Zeta3Domain2
+}
 
-def dump_bloom_to_file(identifier, lhs):
-    with open(BLOOM_LOCAL_PATH.format(identifier), 'wb') as f:
-        lhs.bloom.tofile(f)
+
+def store_execution_to_json(dest_file_name, enumerator_type, poly_domain, const_list):
+    with open(dest_file_name, 'w') as f: 
+        chunk_data = {
+            "an_coefs": poly_domain.a_coef_range,
+            "bn_coefs": poly_domain.b_coef_range,
+            "enumerator": enumerator_type,
+            "domain_type": poly_domain.__class__.__name__,
+            "const_list": const_list
+        }
+        json.dump(chunk_data, f)
 
 
-def to_json(identifier, enumerator_type, domain, domain_type, const_list):
-    number_of_chunks = poly_search_domain.num_iterations // SPLITTED_DOMAIN_CHUNK_SIZE
-    domain_chunks = poly_search_domain.split_domains_to_processes(number_of_chunks)
+def split_to_jsons(identifier, enumerator_type, domain, const_list):
+    if enumerator_type not in ALLOWED_ENUMERATORS:
+        raise ValueError(f"Required enumerator is not supported. Use one from the following:\n{ALLOWED_ENUMERATORS}")
+    number_of_chunks = domain.num_iterations // SPLIT_DOMAIN_CHUNK_SIZE
+    domain_chunks = domain.split_domains_to_processes(number_of_chunks)
     id_max_len = len(str(len(domain_chunks)))
     os.mkdir(identifier)
 
     for i, chunk in enumerate(domain_chunks):
-        dest_file_name = JSON_FORMAT.format(
+        dest_file_name = JSON_NAME_FORMAT.format(
             folder=identifier, 
-            id=str(i).zfill(id_max_len))
-        with open(dest_file_name, 'w') as f: 
-            chunk_data = {
-                "an_coefs": chunk.a_coef_range,
-                "bn_coefs": chunk.b_coef_range,
-                "enumerator": enumerator_type,
-                "domain_type": domain_type,
-                "const_list": const_list
-            }
-            json.dump(chunk_data,f)
-            
-def get_consts_objects(consts):
-    const_objects = []
-    for i in consts:
-        if isinstance(i, tuple) or isinstance(i, list):
-            const_objects.append(g_const_dict[i[0]](i[1]))
-        else:
-            const_objects.append(g_const_dict[i])
-    return const_objects
+            filename=f"{identifier}_{str(i).zfill(id_max_len)}")
+        store_execution_to_json(dest_file_name, enumerator_type, chunk, const_list)
 
-    
+
 def main():
     # Change the following arguments as you wish 
-    const_list = ['e']
-    saved_hash = 'e_lhs_dept5_db'
-    lhs_search_limit = 5
-    identifier = None # distinct name for generated json
+    const_list = [('zeta', 3)]
+    identifier = None  # distinct name for generated json
 
-    const_objects = get_consts_objects(const_list)
     identifier = identifier if identifier else time.strftime("%y%m%d_%H%M%S")
-    lhs = LHSHashTable(
-        saved_hash,
-        lhs_search_limit,
-        const_objects) 
+    
+    poly_search_domain = Zeta3Domain2(
+        [(1, 100), (1, 100)],
+        (1, 50))
 
-    poly_search_domain = Zeta3Domain1(
-        [(2, 2), (1, 1), (1, 100), (1, 100)],
-        (-50, -1))
-
-    to_json(identifier, "EfficientGCFEnumerator", poly_search_domain, "Zeta3Domain1", const_list)
-    EfficientGCFEnumerator,
-        lhs,
-        poly_search_domain,
-        const_objects
+    split_to_jsons(identifier, "FREnumerator", poly_search_domain, const_list)
 
 
 if __name__ == '__main__':

--- a/scripts/boinc/split_execution.py
+++ b/scripts/boinc/split_execution.py
@@ -1,0 +1,88 @@
+import os
+import json
+import time
+import ramanujan
+from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+from ramanujan.constants import g_const_dict
+from ramanujan.LHSHashTable import LHSHashTable
+from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
+from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
+
+
+"""
+In this script, we create multiple jobs from a single execution scheme. 
+For each job save a json that stores the execution parameters. 
+Those jsons will be sent to different hosts from a BOINC server
+
+The bloom filter is saved 
+"""
+SPLITTED_DOMAIN_CHUNK_SIZE = 100_000
+BLOOM_LOCAL_PATH = "./{0}_bloom.bin"
+JSON_FORMAT = "./{folder}/{id}.json"
+
+ALLOWD_ENUMERATORS = [
+    "EfficientGCFEnumerator"
+]
+
+def dump_bloom_to_file(identifier, lhs):
+    with open(BLOOM_LOCAL_PATH.format(identifier), 'wb') as f:
+        lhs.bloom.tofile(f)
+
+
+def to_json(identifier, enumerator_type, domain, domain_type, const_list):
+    number_of_chunks = poly_search_domain.num_iterations // SPLITTED_DOMAIN_CHUNK_SIZE
+    domain_chunks = poly_search_domain.split_domains_to_processes(number_of_chunks)
+    id_max_len = len(str(len(domain_chunks)))
+    os.mkdir(identifier)
+
+    for i, chunk in enumerate(domain_chunks):
+        dest_file_name = JSON_FORMAT.format(
+            folder=identifier, 
+            id=str(i).zfill(id_max_len))
+        with open(dest_file_name, 'w') as f: 
+            chunk_data = {
+                "an_coefs": chunk.a_coef_range,
+                "bn_coefs": chunk.b_coef_range,
+                "enumerator": enumerator_type,
+                "domain_type": domain_type,
+                "const_list": const_list
+            }
+            json.dump(chunk_data,f)
+            
+def get_consts_objects(consts):
+    const_objects = []
+    for i in consts:
+        if isinstance(i, tuple) or isinstance(i, list):
+            const_objects.append(g_const_dict[i[0]](i[1]))
+        else:
+            const_objects.append(g_const_dict[i])
+    return const_objects
+
+    
+def main():
+    # Change the following arguments as you wish 
+    const_list = ['e']
+    saved_hash = 'e_lhs_dept5_db'
+    lhs_search_limit = 5
+    identifier = None # distinct name for generated json
+
+    const_objects = get_consts_objects(const_list)
+    identifier = identifier if identifier else time.strftime("%y%m%d_%H%M%S")
+    lhs = LHSHashTable(
+        saved_hash,
+        lhs_search_limit,
+        const_objects) 
+
+    poly_search_domain = Zeta3Domain1(
+        [(2, 2), (1, 1), (1, 100), (1, 100)],
+        (-50, -1))
+
+    to_json(identifier, "EfficientGCFEnumerator", poly_search_domain, "Zeta3Domain1", const_list)
+    EfficientGCFEnumerator,
+        lhs,
+        poly_search_domain,
+        const_objects
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/zeta3_fr_results.py
+++ b/scripts/zeta3_fr_results.py
@@ -1,10 +1,9 @@
-from ramanujan.LHSHashTable import LHSHashTable
 from ramanujan.enumerators.FREnumerator import FREnumerator
 from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
 from ramanujan.constants import g_const_dict
 
 """
-This script enumerates GCFs for zeta(3) using the FR algorithem.
+This script enumerates GCFs for zeta(3) using the FR algorithm.
 It uses a specific family of series that tends to generate conjectures for zeta(3)
 The family is defined under ramanujan.poly_domains.Zeta3Domain3
 

--- a/scripts/zeta3_fr_results.py
+++ b/scripts/zeta3_fr_results.py
@@ -1,6 +1,8 @@
 from ramanujan.enumerators.FREnumerator import FREnumerator
 from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
 from ramanujan.constants import g_const_dict
+from ramanujan.multiprocess_enumeration import multiprocess_enumeration
+
 
 """
 This script enumerates GCFs for zeta(3) using the FR algorithm.
@@ -11,19 +13,31 @@ It uses the following series:
 a(n) = x0(n**3 + (n+1)**3) + x1(2n+1)
 b(n) = x2*n^6
 """
- 
-# define the poly domain
-poly_search_domain = Zeta3Domain2(
-    [(1, 3), (-20, 20)],
-    (1, 2))
 
-# create an enumerator to iter thought the poly domain and compare it to the lhs table
-enumerator = FREnumerator(
-    poly_search_domain,
-    [g_const_dict['zeta'](3)]
-)
 
-results = enumerator.full_execution()
-print("{} results found!".format(len(results)))
-for r in results:
-	print(r)
+def main():
+    # define the poly domain
+    poly_search_domain = Zeta3Domain2(
+        [(1, 3), (-20, 20)],
+        (1, 2))
+
+    # create an enumerator to iter thought the poly domain and compare it to the lhs table
+    enumerator = FREnumerator(
+        poly_search_domain,
+        [g_const_dict['zeta'](3)]
+    )
+
+    # results = enumerator.full_execution()
+    results = multiprocess_enumeration(
+        FREnumerator,
+        None, # No LHS in FREnumerator
+        poly_search_domain,
+        [g_const_dict['zeta'](3)],
+        4)
+
+    print("{} results found!".format(len(results)))
+    for r in results:
+        print(r)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/zeta3_fr_results.py
+++ b/scripts/zeta3_fr_results.py
@@ -1,0 +1,29 @@
+from ramanujan.LHSHashTable import LHSHashTable
+from ramanujan.enumerators.FREnumerator import FREnumerator
+from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
+from ramanujan.constants import g_const_dict
+
+"""
+This script enumerates GCFs for zeta(3) using the FR algorithem.
+It uses a specific family of series that tends to generate conjectures for zeta(3)
+The family is defined under ramanujan.poly_domains.Zeta3Domain3
+
+It uses the following series:
+a(n) = x0(n**3 + (n+1)**3) + x1(2n+1)
+b(n) = x2*n^6
+"""
+ 
+# define the poly domain
+poly_search_domain = Zeta3Domain2(
+    [(1, 3), (-20, 20)],
+    (-4, -1))
+
+# create an enumerator to iter thought the poly domain and compare it to the lhs table
+enumerator = FREnumerator(
+    poly_search_domain,
+    [g_const_dict['zeta'](3)]
+)
+
+results = enumerator.full_execution()
+print("{} results found!".format(len(results)))
+print(results)

--- a/scripts/zeta3_fr_results.py
+++ b/scripts/zeta3_fr_results.py
@@ -21,16 +21,10 @@ def main():
         [(1, 3), (-20, 20)],
         (1, 2))
 
-    # create an enumerator to iter thought the poly domain and compare it to the lhs table
-    enumerator = FREnumerator(
-        poly_search_domain,
-        [g_const_dict['zeta'](3)]
-    )
-
     # results = enumerator.full_execution()
     results = multiprocess_enumeration(
         FREnumerator,
-        None, # No LHS in FREnumerator
+        None,  # No LHS in FREnumerator
         poly_search_domain,
         [g_const_dict['zeta'](3)],
         4)
@@ -38,6 +32,7 @@ def main():
     print("{} results found!".format(len(results)))
     for r in results:
         print(r)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/zeta3_fr_results.py
+++ b/scripts/zeta3_fr_results.py
@@ -15,7 +15,7 @@ b(n) = x2*n^6
 # define the poly domain
 poly_search_domain = Zeta3Domain2(
     [(1, 3), (-20, 20)],
-    (-4, -1))
+    (1, 2))
 
 # create an enumerator to iter thought the poly domain and compare it to the lhs table
 enumerator = FREnumerator(
@@ -25,4 +25,5 @@ enumerator = FREnumerator(
 
 results = enumerator.full_execution()
 print("{} results found!".format(len(results)))
-print(results)
+for r in results:
+	print(r)

--- a/tests/conjectures_tests.py
+++ b/tests/conjectures_tests.py
@@ -4,6 +4,7 @@ from ramanujan.LHSHashTable import LHSHashTable
 from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
 from ramanujan.enumerators.RelativeGCFEnumerator import RelativeGCFEnumerator, gcf_calculation_to_precision, \
     NotConverging
+from ramanujan.enumerators.FREnumerator import FREnumerator
 from ramanujan.poly_domains.CartesianProductPolyDomain import CartesianProductPolyDomain
 from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
 from ramanujan.poly_domains.Zeta3Domain2 import Zeta3Domain2
@@ -215,6 +216,33 @@ class APITests(unittest.TestCase):
             except NotConverging:
                 exception_caught = True
             self.assertTrue(exception_caught)
+
+    def test_fr_enumerator(self):
+        # define the poly domain
+        poly_search_domain = Zeta3Domain2(
+            [(1, 3), (-20, 20)],
+            (1, 2))
+
+        # create an enumerator to iter thought the poly domain and compare it to the lhs table
+        enumerator = FREnumerator(
+            poly_search_domain,
+            [g_const_dict['zeta'](3)]
+        )
+        
+        results = get_testable_data(enumerator.full_execution())
+
+        self.assertEqual(len(results), 10)
+
+        self.assertIn(((1, 0), (1,), [1, 0, 0], [0, 1, 0]), results)
+        self.assertIn(((1, 4), (1,), [0, 1, 0], [0, -1, 1]), results)
+        self.assertIn(((1, 12), (1,), [-8, 0, 0], [9, -8, 0]), results)
+        self.assertIn(((2, -1), (2,), [1, 0, -1], [0, 0, -1]), results)
+        self.assertIn(((2, 0), (2,), [-2, 2, 0], [0, -1, 1]), results)
+        self.assertIn(((2, 3), (2,), [-2, 0, 0], [8, -7, 0]), results)
+        self.assertIn(((2, 8), (2,), [0, 2, 0], [0, -1, 1]), results)
+        self.assertIn(((2, 13), (2,), None, None), results)
+        self.assertIn(((2, 15), (2,), [0, -54, 0], [0, 224, -189]), results)
+        self.assertIn(((3, -2), (1,), [0, -8, 0], [0, 0, -7]), results)
 
 
 if __name__ == '__main__':

--- a/tests/conjectures_tests.py
+++ b/tests/conjectures_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from ramanujan.LHSHashTable import LHSHashTable
 from ramanujan.enumerators.EfficientGCFEnumerator import EfficientGCFEnumerator
+from ramanujan.enumerators.RelativeGCFEnumerator import RelativeGCFEnumerator
 from ramanujan.poly_domains.CartesianProductPolyDomain import CartesianProductPolyDomain
 from ramanujan.poly_domains.Zeta3Domain1 import Zeta3Domain1
 from ramanujan.constants import g_const_dict
@@ -50,24 +51,32 @@ class APITests(unittest.TestCase):
             (-16, -1)  # bn coef
             )
 
-        enumerator = EfficientGCFEnumerator(
+        efficient_enumerator = EfficientGCFEnumerator(
             lhs,
             poly_search_domain,
             [g_const_dict['zeta'](3)]
             )
+        relative_enumerator = RelativeGCFEnumerator(
+            lhs,
+            poly_search_domain,
+            [g_const_dict['zeta'](3)]
+        )
 
-        results = get_testable_data(enumerator.full_execution())
+        efficient_enumerator_results = get_testable_data(efficient_enumerator.full_execution())
+        relative_enumerator_results = get_testable_data(relative_enumerator.full_execution())
 
-        self.assertEqual(len(results), 3)
+        self.assertEqual(efficient_enumerator_results, relative_enumerator_results)
+
+        self.assertEqual(len(relative_enumerator_results), 3)
         self.assertIn(
             ((2, 1, 3, 1), (-1,), (8, 0), (0, 7)),
-            results)
+            relative_enumerator_results)
         self.assertIn(
             ((2, 1, 5, 2), (-16,), (12, 0), (0, 7)),
-            results)
+            relative_enumerator_results)
         self.assertIn(
             ((2, 1, 17, 5), (-1,), (6, 0), (0, 1)),
-            results)
+            relative_enumerator_results)
 
     def test_MITM_api3(self):
         saved_hash = 'pi_lhs_dept20'

--- a/tests/conjectures_tests.py
+++ b/tests/conjectures_tests.py
@@ -153,37 +153,40 @@ class APITests(unittest.TestCase):
 
     def test_poly_domain_split(self):
         """
-        making sure that the domain is splitted currectly
-        1. checking if the approximate size of a splitted domain is the same as the
+        making sure that the domain is split correctly
+        1. checking if the approximate size of a split domain is the same as the
            original domain
-        2. checking if all the items in the splitted domain are
+        2. checking if all the items in the split domain are
         """
+        def compare_domains(domain, split_domain):
+            all_polys = [i for i in domain.iter_polys('b')]
+            for sub_domain in split_domain:
+                for polys in sub_domain.iter_polys('a'):
+                    # checking if a value is present this way imporves execution times drasticly
+                    try:
+                        all_polys.remove(polys)
+                    except ValueError:
+                        self.assertIn(polys, all_polys)
+            self.assertEqual(len(all_polys), 0)
+
         # coef ranges are 29, aiming for primes that screw with even splitting
         cartesian_domain = CartesianProductPolyDomain(
             2, [-30, 30],
             3, [-10, 19])
-        splitted_cartesian_domain = cartesian_domain.split_domains_to_processes(5)
+        split_cartesian_domain1 = cartesian_domain.split_domains_to_processes(5)
+        split_cartesian_domain2 = cartesian_domain.split_domains_to_processes(51)
 
-        self.assertEqual(cartesian_domain.num_iterations, sum([i.num_iterations for i in splitted_cartesian_domain]))
-        print('passed1')
+        self.assertEqual(cartesian_domain.num_iterations, sum([i.num_iterations for i in split_cartesian_domain1]))
+        self.assertEqual(cartesian_domain.num_iterations, sum([i.num_iterations for i in split_cartesian_domain2]))
+
         # the zeta domain checks for convergences condition when iterating over coefs
         # so the approximate size is bigger then the one actually used
         original_zeta_domain = Zeta3Domain1(
             [(2, 10), (1, 1), (1, 30), (1, 10)],
             (-10, -1)
         )
-        splitted_zeta_domain = original_zeta_domain.split_domains_to_processes(7)
-
-        all_zeta_polys = [i for i in original_zeta_domain.iter_polys('b')]
-        for sub_domain in splitted_zeta_domain:
-            for polys in sub_domain.iter_polys('a'):
-                # checking if a value is present this way imporves execution times drasticly
-                try:
-                    all_zeta_polys.remove(polys)
-                except ValueError:
-                    self.assertIn(polys, all_zeta_polys)
-
-        self.assertEqual(len(all_zeta_polys), 0)
+        compare_domains(original_zeta_domain, original_zeta_domain.split_domains_to_processes(7))
+        compare_domains(original_zeta_domain, original_zeta_domain.split_domains_to_processes(51))
 
     def test_gcf_calculation_to_precision(self):
         with mpmath.workdps(200):

--- a/tests/conjectures_tests.py
+++ b/tests/conjectures_tests.py
@@ -237,15 +237,14 @@ class APITests(unittest.TestCase):
         self.assertEqual(len(results), 10)
 
         self.assertIn(((1, 0), (1,), [1, 0, 0], [0, 1, 0]), results)
-        self.assertIn(((1, 4), (1,), [0, 1, 0], [0, -1, 1]), results)
-        self.assertIn(((1, 12), (1,), [-8, 0, 0], [9, -8, 0]), results)
-        self.assertIn(((2, -1), (2,), [1, 0, -1], [0, 0, -1]), results)
-        self.assertIn(((2, 0), (2,), [-2, 2, 0], [0, -1, 1]), results)
-        self.assertIn(((2, 3), (2,), [-2, 0, 0], [8, -7, 0]), results)
-        self.assertIn(((2, 8), (2,), [0, 2, 0], [0, -1, 1]), results)
+        self.assertIn(((1, 4), (1,), [1, 0, 0], [-1, 1, 0]), results)
+        self.assertIn(((1, 12), (1,), [8, 0, 0], [-9, 8, 0]), results)
+        self.assertIn(((2, 0), (2,), [2, 0, 0], [0, 1, 0]), results)
+        self.assertIn(((2, 3), (2,), [2, 0, 0], [-8, 7, 0]), results)
+        self.assertIn(((2, 8), (2,), [2, 0, 0], [-1, 1, 0]), results)
         self.assertIn(((2, 13), (2,), None, None), results)
-        self.assertIn(((2, 15), (2,), [0, -54, 0], [0, 224, -189]), results)
-        self.assertIn(((3, -2), (1,), [0, -8, 0], [0, 0, -7]), results)
+        self.assertIn(((2, 15), (2,), [54, 0, 0], [-224, 189, 0]), results)
+        self.assertIn(((3, -2), (1,), [8, 0, 0], [0, 7, 0]), results)
 
 
 if __name__ == '__main__':

--- a/tests/conjectures_tests.py
+++ b/tests/conjectures_tests.py
@@ -207,8 +207,8 @@ class APITests(unittest.TestCase):
             key, precision = gcf_calculation_to_precision(an_iter, bn_iter, 100, 1, 7)
             self.assertEqual(
                 key,
-                8319073720000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
-            self.assertEqual(precision, 9)
+                8319073728000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+            self.assertEqual(precision, 11)
 
             # GCF that doesn't converge at all
             an_iter = an_iter_func((1, 0), 200, start_n=0)


### PR DESCRIPTION
This is a big PR that contains 3 major changes
1. introducing RelativeEnumerator and FREnumerator
   FR enumerator doesn't use a bloom filter. This lead to some changes in abstract enumerator and in the multiprocessing script
2. introducing new domains for zeta
3. setting up BOINC support  
   - a script that stores execution configuration to file, and a matching script that uses this file
   - utill now we've split a domain by the biggest range, so this domain:
      an = (1, 10),  (1, 5); bn = (1, 5)
     was split by the first coef of an, and we could've split it to up to 10 processes. 
      if we want to split this domain using BOINC, we might need to split a domain to more jobs then the size of the biggest range. This PR solves this problem on CaresianProductPolyDomain